### PR TITLE
Introduce listenLetsEncrypt option

### DIFF
--- a/doc/server-config.md
+++ b/doc/server-config.md
@@ -62,6 +62,9 @@ JSON. It can either be in [simple mode](#simplemode) (for basic configurations),
 * `listen`: The port (like "80" or ":80") or IP & port (like "10.0.0.2:8080")
   to listen for HTTP(s) connections on.
 
+* `listenLetsEncrypt`: The port (like "80" or ":80") or IP & port (like
+  "10.0.0.2:8080") to listen for HTTP-01 challanges from Let's Encrypt.
+
 * `shareHandler`: if true, the server's sharing functionality is enabled,
   letting your friends have access to any content you've specifically shared.
   Its URL prefix path defaults to "`/share/`".

--- a/pkg/server/app/app.go
+++ b/pkg/server/app/app.go
@@ -310,6 +310,12 @@ type HandlerConfig struct {
 	// part and a random port.
 	Listen string `json:"listen,omitempty"`
 
+	// Listen is the address (of the form host|ip:port) on which the app
+	// will listen on for the Let's Encrypt http-01 challange.
+	// If empty, the default is the concatenation of the Perkeep server's
+	// Listen host part, and port 80.
+	ListenLetsEncrypt string `json:"listenLetsEncrypt,omitempty"`
+
 	// ServerListen is the Perkeep server's listen address. Defaults to
 	// the ServerBaseURL host part.
 	ServerListen string `json:"serverListen,omitempty"`
@@ -339,14 +345,15 @@ type HandlerConfig struct {
 // prefix and serverBaseURL are used if not found in config.
 func FromJSONConfig(config jsonconfig.Obj, prefix, serverBaseURL string) (HandlerConfig, error) {
 	hc := HandlerConfig{
-		Program:       config.RequiredString("program"),
-		Prefix:        config.OptionalString("prefix", prefix),
-		BackendURL:    config.OptionalString("backendURL", ""),
-		Listen:        config.OptionalString("listen", ""),
-		APIHost:       config.OptionalString("apiHost", ""),
-		ServerListen:  config.OptionalString("serverListen", ""),
-		ServerBaseURL: config.OptionalString("serverBaseURL", serverBaseURL),
-		AppConfig:     config.OptionalObject("appConfig"),
+		Program:           config.RequiredString("program"),
+		Prefix:            config.OptionalString("prefix", prefix),
+		BackendURL:        config.OptionalString("backendURL", ""),
+		Listen:            config.OptionalString("listen", ""),
+		ListenLetsEncrypt: config.OptionalString("listenLetsEncrypt", ""),
+		APIHost:           config.OptionalString("apiHost", ""),
+		ServerListen:      config.OptionalString("serverListen", ""),
+		ServerBaseURL:     config.OptionalString("serverBaseURL", serverBaseURL),
+		AppConfig:         config.OptionalObject("appConfig"),
 	}
 	if err := config.Validate(); err != nil {
 		return HandlerConfig{}, err

--- a/pkg/serverinit/genconfig.go
+++ b/pkg/serverinit/genconfig.go
@@ -218,6 +218,9 @@ func addAppConfig(config map[string]interface{}, appConfig *serverconfig.App, lo
 	if appConfig.Listen != "" {
 		config["listen"] = appConfig.Listen
 	}
+	if appConfig.ListenLetsEncrypt != "" {
+		config["listenLetsEncrypt"] = appConfig.ListenLetsEncrypt
+	}
 	if appConfig.APIHost != "" {
 		config["apiHost"] = appConfig.APIHost
 	}
@@ -1066,6 +1069,9 @@ func (b *lowBuilder) build() (*Config, error) {
 	}
 	if conf.Listen != "" {
 		low["listen"] = conf.Listen
+	}
+	if conf.ListenLetsEncrypt != "" {
+		low["listenLetsEncrypt"] = conf.ListenLetsEncrypt
 	}
 	if conf.PackBlobs && conf.PackRelated {
 		return nil, errors.New("can't use both packBlobs (for 'diskpacked') and packRelated (for 'blobpacked')")

--- a/pkg/types/serverconfig/config.go
+++ b/pkg/types/serverconfig/config.go
@@ -28,9 +28,10 @@ import (
 // serverinit.genLowLevelConfig, and used to configure the various
 // Perkeep components.
 type Config struct {
-	Auth    string `json:"auth"`              // auth scheme and values (ex: userpass:foo:bar).
-	BaseURL string `json:"baseURL,omitempty"` // Base URL the server advertizes. For when behind a proxy.
-	Listen  string `json:"listen"`            // address (of the form host|ip:port) on which the server will listen on.
+	Auth              string `json:"auth"`              // auth scheme and values (ex: userpass:foo:bar).
+	BaseURL           string `json:"baseURL,omitempty"` // Base URL the server advertizes. For when behind a proxy.
+	Listen            string `json:"listen"`            // address (of the form host|ip:port) on which the server will listen on.
+	ListenLetsEncrypt string `json:"listenLetsEncrypt"` // address (of the form host|ip:port) on which the server will listen on for the Let's Encrypt http-01 challange.
 
 	// CamliNetIP is the optional internet-facing IP address for this
 	// Perkeep instance. If set, a name in the camlistore.net domain for
@@ -112,6 +113,12 @@ type App struct {
 	// If empty, the default is the concatenation of the Perkeep server's
 	// Listen host part, and a random port.
 	Listen string `json:"listen,omitempty"`
+
+	// Listen is the address (of the form host|ip:port) on which the app
+	// will listen on for the Let's Encrypt http-01 challange.
+	// If empty, the default is the concatenation of the Perkeep server's
+	// Listen host part, and port 80.
+	ListenLetsEncrypt string `json:"listenLetsEncrypt,omitempty"`
 
 	// BackendURL is the URL of the application's process, always ending in a
 	// trailing slash. It is the URL that the app handler will proxy to when


### PR DESCRIPTION
The default for the Let's Encrypt listen address is still ':80'.  This
`camlistored`flag and config option provides a method to bind to a specific IP
or a different port.

For Iss1078