### PR TITLE
pkg/index: wait for the database to be actually ready when creating kv

### DIFF
--- a/pkg/index/mysql_test.go
+++ b/pkg/index/mysql_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package index_test
 
 import (
+	"fmt"
 	"testing"
 
 	"go4.org/jsonconfig"
@@ -30,11 +31,11 @@ import (
 
 func newMySQLSorted(t *testing.T) (kv sorted.KeyValue, clean func()) {
 	dbname := "camlitest_" + osutil.Username()
-	containerID, ip := dockertest.SetupMySQLContainer(t, dbname)
+	containerID, ip, port := dockertest.SetupMySQLContainer(t, dbname)
 
 	kv, err := sorted.NewKeyValue(jsonconfig.Obj{
 		"type":     "mysql",
-		"host":     ip + ":3306",
+		"host":     fmt.Sprintf("%s:%d", ip, port),
 		"database": dbname,
 		"user":     dockertest.MySQLUsername,
 		"password": dockertest.MySQLPassword,

--- a/pkg/sorted/mysql/mysqlkv_test.go
+++ b/pkg/sorted/mysql/mysqlkv_test.go
@@ -19,6 +19,7 @@ package mysql
 import (
 	"database/sql"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -32,7 +33,7 @@ import (
 // TestMySQLKV tests against a real MySQL instance, using a Docker container.
 func TestMySQLKV(t *testing.T) {
 	dbname := "camlitest_" + osutil.Username()
-	containerID, ip := dockertest.SetupMySQLContainer(t, dbname)
+	containerID, ip, port := dockertest.SetupMySQLContainer(t, dbname)
 	defer containerID.KillRemove(t)
 
 	// TODO(mpl): add test for serverVersion once we host the docker image ourselves
@@ -40,7 +41,7 @@ func TestMySQLKV(t *testing.T) {
 
 	kv, err := sorted.NewKeyValue(jsonconfig.Obj{
 		"type":     "mysql",
-		"host":     ip + ":3306",
+		"host":     fmt.Sprintf("%s:%d", ip, port),
 		"database": dbname,
 		"user":     dockertest.MySQLUsername,
 		"password": dockertest.MySQLPassword,
@@ -54,12 +55,12 @@ func TestMySQLKV(t *testing.T) {
 
 func TestRollback(t *testing.T) {
 	dbname := "camlitest_" + osutil.Username()
-	containerID, ip := dockertest.SetupMySQLContainer(t, dbname)
+	containerID, ip, port := dockertest.SetupMySQLContainer(t, dbname)
 	defer containerID.KillRemove(t)
 
 	kv, err := sorted.NewKeyValue(jsonconfig.Obj{
 		"type":     "mysql",
-		"host":     ip + ":3306",
+		"host":     fmt.Sprintf("%s:%d", ip, port),
 		"database": dbname,
 		"user":     dockertest.MySQLUsername,
 		"password": dockertest.MySQLPassword,


### PR DESCRIPTION
pkg/test/dockertest: publish container port on random host port, because
container IP is actually only reachable when natively on linux. And it
has to be a random, variable, port, otherwise concurrent tests runs would
block each other when trying to bind on same port.

=> makes the MySQL tests in pkg/index pass on darwin.