### PR TITLE
Web UI: viewer for plain text files.

### DIFF
--- a/server/perkeepd/ui/browser_view_detail.js
+++ b/server/perkeepd/ui/browser_view_detail.js
@@ -14,15 +14,16 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-goog.provide('cam.PdfDetail');
+goog.provide('cam.BrowserViewDetail');
 
-// Renders PDFs. This matches files with a "mimeType" of "application/pdf",
-// and displays them by embedding the PDF in an iframe.
+// Renders content that browsers understand natively. Works by embedding it in
+// an iframe.
 //
-// It would be easy to extend this to any content that browsers know how
-// to render themselves.
-cam.PdfDetail = React.createClass({
-	displayName: 'PdfDetail',
+// Note that not all content that browsers understand natively is covered here.
+// For example, images have their own custom support (ImageDetail) which provides
+// a nicer UI.
+cam.BrowserViewDetail = React.createClass({
+	displayName: 'BrowserViewDetail',
 
 	propTypes: {
 		height: React.PropTypes.number.isRequired,
@@ -49,7 +50,12 @@ cam.PdfDetail = React.createClass({
 	},
 });
 
-cam.PdfDetail.getAspect = function(blobref, searchSession) {
+cam.BrowserViewDetail.getAspect = function(blobref, searchSession) {
+	const supportedMimeTypes = [
+		"application/pdf",
+		"text/plain",
+	]
+
 	if(!blobref) {
 		return null;
 	}
@@ -66,7 +72,7 @@ cam.PdfDetail.getAspect = function(blobref, searchSession) {
 	}
 
 
-	if(rm.camliType !== 'file' || rm.file.mimeType !== 'application/pdf') {
+	if(rm.camliType !== 'file' || !supportedMimeTypes.includes(rm.file.mimeType)) {
 		return null;
 	}
 
@@ -74,7 +80,7 @@ cam.PdfDetail.getAspect = function(blobref, searchSession) {
 		fragment: 'document',
 		title: 'Document',
 		createContent: function(size, backwardPiggy) {
-			return React.createElement(cam.PdfDetail, {
+			return React.createElement(cam.BrowserViewDetail, {
 				resolvedMeta: rm,
 				height: size.height,
 				width: size.width,

--- a/server/perkeepd/ui/index.js
+++ b/server/perkeepd/ui/index.js
@@ -52,7 +52,7 @@ goog.require('cam.Dialog');
 goog.require('cam.MapAspect');
 goog.require('cam.Header');
 goog.require('cam.Navigator');
-goog.require('cam.PdfDetail');
+goog.require('cam.BrowserViewDetail');
 goog.require('cam.PermanodeDetail');
 goog.require('cam.permanodeUtils');
 goog.require('cam.reactUtil');
@@ -252,7 +252,7 @@ cam.IndexPage = React.createClass({
 		var specificAspects = [
 			cam.ImageDetail.getAspect,
 			cam.AudioDetail.getAspect,
-			cam.PdfDetail.getAspect,
+			cam.BrowserViewDetail.getAspect,
 			this.getDirAspect_.bind(null),
 		];
 


### PR DESCRIPTION
This just generalizes PdfDetail to also recognize text/plain. It has
been renamed BrowserViewDetail to reflect its more general nature.

Adding more formats will now be trivial: just add entries to the
`supportedMimeTypes` array.