### PR TITLE
pkg/blobserver/fsbacked: add blobserver using existing local files as storage [WIP]

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/lib/pq v1.1.1
 	github.com/mailgun/mailgun-go v0.0.0-20171127222028-17e8bd11e87c
 	github.com/mattn/go-mastodon v0.0.5-0.20190517015615-8f6192e26b66
-	github.com/mattn/go-sqlite3 v1.6.0
+	github.com/mattn/go-sqlite3 v1.10.0
 	github.com/miekg/dns v0.0.0-20161003181808-3f1f7c8ec9ea
 	github.com/nf/cr2 v0.0.0-20140528043846-05d46fef4f2f
 	github.com/onsi/ginkgo v1.8.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/nf/cr2 v0.0.0-20140528043846-05d46fef4f2f
 	github.com/onsi/ginkgo v1.8.0 // indirect
 	github.com/onsi/gomega v1.5.0 // indirect
-	github.com/pkg/errors v0.8.0 // indirect
+	github.com/pkg/errors v0.8.0
 	github.com/pkg/sftp v0.0.0-20180419200840-5bf2a174b604
 	github.com/plaid/plaid-go v0.0.0-20161222051224-02b6af68061b
 	github.com/russross/blackfriday v2.0.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -105,8 +105,8 @@ github.com/mattn/go-isatty v0.0.5/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hd
 github.com/mattn/go-isatty v0.0.7/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-mastodon v0.0.5-0.20190517015615-8f6192e26b66 h1:TbnaLJhq+sFuqZ1wxdfF5Uk7A2J41iOobCCFnLI+RPE=
 github.com/mattn/go-mastodon v0.0.5-0.20190517015615-8f6192e26b66/go.mod h1:ZBkemyyYYhNAN5JJ0H/ZSW8HfPCW45rHFHyWNwSfpTA=
-github.com/mattn/go-sqlite3 v1.6.0 h1:TDwTWbeII+88Qy55nWlof0DclgAtI4LqGujkYMzmQII=
-github.com/mattn/go-sqlite3 v1.6.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
+github.com/mattn/go-sqlite3 v1.10.0 h1:jbhqpg7tQe4SupckyijYiy0mJJ/pRyHvXf7JdWK860o=
+github.com/mattn/go-sqlite3 v1.10.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/mattn/go-tty v0.0.0-20190424173100-523744f04859/go.mod h1:XPvLUNfbS4fJH25nqRHfWLMa1ONC8Amw+mIA639KxkE=
 github.com/miekg/dns v0.0.0-20161003181808-3f1f7c8ec9ea h1:OeKTTfcv1UiDsqNpa0rb8hbcH1WFoh9Lx7rgyiQeQvs=
 github.com/miekg/dns v0.0.0-20161003181808-3f1f7c8ec9ea/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=

--- a/pkg/blobserver/fsbacked/fsbacked.go
+++ b/pkg/blobserver/fsbacked/fsbacked.go
@@ -1,0 +1,322 @@
+package fsbacked
+
+import (
+	"context"
+	"database/sql"
+	"io"
+	"math"
+	"os"
+	"path/filepath"
+
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/pkg/errors"
+
+	"perkeep.org/pkg/blob"
+	"perkeep.org/pkg/blobserver"
+)
+
+type Storage struct {
+	blobserver.Storage
+
+	root string
+	db   *sql.DB
+
+	nested blobserver.Storage
+}
+
+func New(ctx context.Context, root, dbConnStr string, nested blobserver.Storage) (*Storage, error) {
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		return nil, errors.Wrapf(err, "making absolute path from %s", root)
+	}
+
+	db, err := sql.Open("sqlite3", dbConnStr)
+	if err != nil {
+		return nil, errors.Wrapf(err, "opening db at %s", dbConnStr)
+	}
+
+	_, err = db.ExecContext(ctx, schema)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating db schema")
+	}
+
+	return &Storage{
+		root:   absRoot,
+		db:     db,
+		nested: nested,
+	}, nil
+}
+
+func (s *Storage) Fetch(ctx context.Context, ref blob.Ref) (io.ReadCloser, uint32, error) {
+	const q = `SELECT path FROM file WHERE ref = $1 LIMIT 1`
+	var path string
+	err := s.db.QueryRowContext(ctx, q, ref).Scan(&path)
+	if err == sql.ErrNoRows {
+		return s.nested.Fetch(ctx, ref)
+	}
+	if err != nil {
+		return nil, 0, errors.Wrap(err, "querying db")
+	}
+	abspath, size, err := s.stat(path)
+	if err != nil {
+		return nil, 0, errors.Wrapf(err, "getting size of file %s", abspath)
+	}
+	f, err := os.Open(abspath)
+	return f, size, errors.Wrapf(err, "opening file %s", abspath)
+}
+
+func (s *Storage) ReceiveBlob(ctx context.Context, ref blob.Ref, r io.Reader) (blob.SizedRef, error) {
+	f, ok := r.(*os.File)
+	if !ok {
+		return s.nested.ReceiveBlob(ctx, ref, r)
+	}
+
+	abspath, err := filepath.Abs(f.Name())
+	if err != nil {
+		return blob.SizedRef{}, errors.Wrapf(err, "getting absolute path of %s", f.Name())
+	}
+
+	relpath := s.findRelPath(abspath)
+	if relpath == "" {
+		// File is outside s's tree.
+		return s.nested.ReceiveBlob(ctx, ref, r)
+	}
+
+	_, size, err := s.stat(relpath)
+	if err != nil {
+		return blob.SizedRef{}, errors.Wrapf(err, "statting %s", abspath)
+	}
+
+	const q = `INSERT INTO file (ref, path) VALUES ($1, $2) ON CONFLICT DO NOTHING`
+	res, err := s.db.ExecContext(ctx, q, ref, relpath)
+	if err != nil {
+		return blob.SizedRef{}, errors.Wrap(err, "writing to db")
+	}
+	aff, err := res.RowsAffected()
+	if err != nil {
+		return blob.SizedRef{}, errors.Wrap(err, "counting affected rows")
+	}
+	if aff == 0 {
+		// Path was already present. Check that it has the right ref.
+		const checkQ = `SELECT ref FROM file WHERE path = $1`
+		var got blob.Ref
+		err = s.db.QueryRowContext(ctx, checkQ, relpath).Scan(&got)
+		if err != nil {
+			return blob.SizedRef{}, errors.Wrapf(err, "checking existing ref for %s", relpath)
+		}
+		if got != ref {
+			return blob.SizedRef{}, blobserver.ErrCorruptBlob
+		}
+	}
+	return blob.SizedRef{Ref: ref, Size: size}, nil
+}
+
+func (s *Storage) StatBlobs(ctx context.Context, refs []blob.Ref, fn func(blob.SizedRef) error) error {
+	var nested []blob.Ref
+	for _, ref := range refs {
+		const q = `SELECT path FROM file WHERE ref = $1 LIMIT 1`
+		var path string
+		err := s.db.QueryRowContext(ctx, q, ref).Scan(&path)
+		if err == sql.ErrNoRows {
+			nested = append(nested, ref)
+			continue
+		}
+		if err != nil {
+			return errors.Wrapf(err, "querying db for %s", ref)
+		}
+		_, size, err := s.stat(path)
+		if err != nil {
+			return errors.Wrapf(err, "statting %s", path)
+		}
+		err = fn(blob.SizedRef{Ref: ref, Size: size})
+		if err != nil {
+			return err
+		}
+	}
+	if len(nested) > 0 {
+		return s.nested.StatBlobs(ctx, nested, fn)
+	}
+	return nil
+}
+
+func (s *Storage) EnumerateBlobs(ctx context.Context, dest chan<- blob.SizedRef, after string, limit int) error {
+	defer close(dest)
+
+	if limit == 0 {
+		return nil
+	}
+
+	nestedCh := make(chan blob.SizedRef)
+	nestedErr := make(chan error, 1)
+
+	nestedCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	go func() {
+		defer close(nestedErr)
+
+		nestedErr <- s.nested.EnumerateBlobs(nestedCtx, nestedCh, after, limit)
+	}()
+
+	const q = `SELECT ref, path FROM file WHERE ref > $1 ORDER BY ref`
+	rows, err := s.db.QueryContext(ctx, q, after)
+	if err != nil {
+		return errors.Wrap(err, "querying db")
+	}
+	defer rows.Close()
+
+	var (
+		dbloop     = true
+		nestedloop = true
+		last       blob.Ref
+		dbref      *blob.Ref
+		path       string
+		nestedref  *blob.SizedRef
+	)
+	for {
+		if nestedloop && nestedref == nil {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+
+			case err = <-nestedErr:
+				if err != nil {
+					return errors.Wrap(err, "enumerating blobs from nested storage")
+				}
+
+			case ref, ok := <-nestedCh:
+				if ok {
+					nestedref = &ref
+				} else {
+					nestedloop = false
+				}
+			}
+		}
+
+		if dbloop && dbref == nil {
+			if rows.Next() {
+				var ref blob.Ref
+
+				err = rows.Scan(&ref, &path)
+				if err != nil {
+					return errors.Wrap(err, "scanning db row")
+				}
+				dbref = &ref
+			} else {
+				dbloop = false
+				if err = rows.Err(); err != nil {
+					return errors.Wrap(err, "reading db rows")
+				}
+			}
+		}
+
+		if nestedref == nil && dbref == nil {
+			// Done.
+			return nil
+		}
+
+		if nestedref != nil && (nestedref.Ref.Less(last) || nestedref.Ref == last) {
+			nestedref = nil
+			continue
+		}
+
+		if dbref != nil && (dbref.Less(last) || *dbref == last) {
+			dbref = nil
+			continue
+		}
+
+		var out *blob.SizedRef
+
+		if nestedref != nil && (dbref == nil || nestedref.Ref.Less(*dbref)) {
+			out = nestedref
+			nestedref = nil
+		} else if dbref != nil && (nestedref == nil || dbref.Less(nestedref.Ref)) {
+			_, size, err := s.stat(path)
+			if err != nil {
+				return errors.Wrapf(err, "statting %s", path)
+			}
+			out = &blob.SizedRef{
+				Ref:  *dbref,
+				Size: size,
+			}
+			dbref = nil
+		}
+
+		if out != nil {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+
+			case dest <- *out:
+				last = out.Ref
+				if limit > 0 {
+					limit--
+					if limit == 0 {
+						return nil
+					}
+				}
+			}
+		}
+	}
+}
+
+func (s *Storage) RemoveBlobs(ctx context.Context, refs []blob.Ref) error {
+	for _, ref := range refs {
+		err := s.removeBlob(ctx, ref)
+		if err != nil {
+			return err
+		}
+	}
+	return s.nested.RemoveBlobs(ctx, refs)
+}
+
+func (s *Storage) removeBlob(ctx context.Context, ref blob.Ref) error {
+	const q = `DELETE FROM file WHERE ref = $1`
+	_, err := s.db.ExecContext(ctx, q, ref)
+	return err
+}
+
+// ErrTooBig is the error when a file's size will not fit into a uint32.
+var ErrTooBig = errors.New("file size is too big")
+
+func (s *Storage) stat(path string) (string, uint32, error) {
+	abspath := filepath.Join(s.root, path)
+	fi, err := os.Stat(abspath)
+	if err != nil {
+		return "", 0, errors.Wrapf(err, "statting %s", abspath)
+	}
+	size := fi.Size()
+	if size > math.MaxUint32 {
+		return "", 0, ErrTooBig
+	}
+	return abspath, uint32(size), nil
+}
+
+func (s *Storage) findRelPath(path string) string {
+	if s.root == path {
+		return ""
+	}
+	var (
+		base = filepath.Base(path)
+		dir  = filepath.Dir(path)
+	)
+	if dir == s.root {
+		return base
+	}
+	if dir == base {
+		return ""
+	}
+	if r := s.findRelPath(dir); r != "" {
+		return filepath.Join(r, base)
+	}
+	return ""
+}
+
+const schema = `
+	CREATE TABLE IF NOT EXISTS file (
+		path TEXT NOT NULL PRIMARY KEY,
+		ref TEXT NOT NULL
+	);
+
+	CREATE INDEX IF NOT EXISTS file_ref ON file (ref);
+`

--- a/pkg/blobserver/fsbacked/fsbacked_test.go
+++ b/pkg/blobserver/fsbacked/fsbacked_test.go
@@ -1,9 +1,150 @@
 package fsbacked
 
 import (
+	"context"
 	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
 	"testing"
+
+	"perkeep.org/pkg/blob"
+	"perkeep.org/pkg/blobserver/memory"
 )
+
+func TestStore(t *testing.T) {
+	tmpdir, err := ioutil.TempDir("", "fsbacked")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = os.MkdirAll(tmpdir, 0700)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpdir)
+
+	rootdir := filepath.Join(tmpdir, "root")
+	err = os.Mkdir(rootdir, 0700)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dbfile := filepath.Join(tmpdir, "db")
+
+	foofile := filepath.Join(rootdir, "foo")
+	err = ioutil.WriteFile(foofile, []byte("foo"), 0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const foo224 = "sha224-0808f64e60d58979fcb676c96ec938270dea42445aeefcd3a4e6f8db"
+	fooref, _ := blob.Parse(foo224)
+
+	barfile := filepath.Join(tmpdir, "foo") // n.b. not under rootdir
+	err = ioutil.WriteFile(barfile, []byte("bar"), 0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const bar224 = "sha224-07daf010de7f7f0d8d76a76eb8d1eb40182c8d1e7a3877a6686c9bf0"
+	barref, _ := blob.Parse(bar224)
+
+	cases := []struct {
+		addfiles       []string
+		addrefs        []blob.Ref
+		wantnestedrefs []blob.Ref
+	}{
+		{},
+		{
+			addfiles: []string{foofile},
+			addrefs:  []blob.Ref{fooref},
+		},
+		{
+			addfiles:       []string{barfile},
+			addrefs:        []blob.Ref{barref},
+			wantnestedrefs: []blob.Ref{barref},
+		},
+		{
+			addfiles:       []string{foofile, barfile},
+			addrefs:        []blob.Ref{fooref, barref},
+			wantnestedrefs: []blob.Ref{barref},
+		},
+	}
+
+	for i, c := range cases {
+		t.Run(fmt.Sprintf("case_%02d", i+1), func(t *testing.T) {
+			ctx := context.Background()
+			nested := new(memory.Storage)
+			fsb, err := New(ctx, rootdir, dbfile, nested)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			add := func(filename string, ref blob.Ref) error {
+				f, err := os.Open(filename)
+				if err != nil {
+					return err
+				}
+				defer f.Close()
+
+				_, err = fsb.ReceiveBlob(ctx, ref, f)
+				return err
+			}
+
+			for j, filename := range c.addfiles {
+				err = add(filename, c.addrefs[j])
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			got := make([]blob.Ref, 0) // `var got []blob.Ref` makes reflect.DeepEqual fail when got is nil
+			ch := make(chan blob.SizedRef)
+
+			go func() {
+				for sr := range ch {
+					got = append(got, sr.Ref)
+				}
+			}()
+
+			err = fsb.EnumerateBlobs(ctx, ch, "", -1)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			want := make([]blob.Ref, len(c.addrefs))
+			copy(want, c.addrefs)
+			sort.Slice(want, func(i, j int) bool { return want[i].Less(want[j]) })
+
+			if !reflect.DeepEqual(got, want) {
+				t.Errorf("got these top-level refs: %v; want %v", got, want)
+			}
+
+			got = got[:0]
+			ch = make(chan blob.SizedRef)
+
+			go func() {
+				for sr := range ch {
+					got = append(got, sr.Ref)
+				}
+			}()
+
+			err = nested.EnumerateBlobs(ctx, ch, "", -1)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			want = make([]blob.Ref, len(c.wantnestedrefs))
+			copy(want, c.wantnestedrefs)
+			sort.Slice(want, func(i, j int) bool { return want[i].Less(want[j]) })
+
+			if !reflect.DeepEqual(got, want) {
+				t.Errorf("got these nested refs: %v; want %v", got, want)
+			}
+		})
+	}
+}
 
 func TestFindRelPath(t *testing.T) {
 	cases := []struct {

--- a/pkg/blobserver/fsbacked/fsbacked_test.go
+++ b/pkg/blobserver/fsbacked/fsbacked_test.go
@@ -1,0 +1,29 @@
+package fsbacked
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestFindRelPath(t *testing.T) {
+	cases := []struct {
+		root, path, want string
+	}{
+		{"a/b", "a/b/c", "c"},
+		{"a/b", "a/b/c/d", "c/d"},
+		{"a/b", "a/b", ""},
+		{"a/b", "a/c", ""},
+		{"a/b", "a", ""},
+		{"a/b", "c/d", ""},
+	}
+
+	for i, c := range cases {
+		t.Run(fmt.Sprintf("case_%02d", i+1), func(t *testing.T) {
+			s := &Storage{root: c.root}
+			got := s.findRelPath(c.path)
+			if got != c.want {
+				t.Errorf("got %s, want %s", got, c.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR is a **preliminary sketch** for a new blobserver type that uses files uploaded to it as their own storage.

When you add a file to an `fsbacked.Storage` that's within the directory tree it controls, an entry is added to a database that maps between files and blobrefs; but the file's contents are not copied anywhere. When fetching the file's content blob later, the database directs the `Storage` to the right local file and the data is served from there.

Adding files _outside_ the directory tree, or adding any other kind of blob, fails over to another blobserver nested inside the `fsbacked.Storage`.

This solves the problem of wanting to add a tree of large files (e.g., videos of my kids growing up) to a local Perkeep instance without storing all the data twice. This should be used only on directory trees whose files do not change, lest the blobrefs in the database become mismatched to their corresponding files.

A number of other changes throughout Perkeep would be needed to make this truly useful. The `io.Reader` presented to a blobserver's `ReceiveBlob` method is usually (always?) some wrapper object (like [checkHashReader](https://github.com/perkeep/perkeep/blob/d342b0e26632217a93a7b9a2ce85acca0c5cd00b/pkg/blobserver/receive.go#L71-L79)) that conceals the underlying `*os.File`, without which `fsbacked.Storage` cannot detect that a file within its tree is being uploaded. And in any case, Perkeep imposes [rather a low limit on blob sizes](https://github.com/perkeep/perkeep/blob/d342b0e26632217a93a7b9a2ce85acca0c5cd00b/pkg/constants/constants.go#L22-L23) for this purpose.

Presented for further discussion.