### PR TITLE
pkg/webserver: use NYTimes/gziphandler

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	bazil.org/fuse v0.0.0-20160811212531-371fbbdaa898
 	cloud.google.com/go v0.39.0
 	github.com/FiloSottile/b2 v0.0.0-20170207175032-b197f7a2c317
+	github.com/NYTimes/gziphandler v1.1.1
 	github.com/aws/aws-sdk-go v1.14.31
 	github.com/bradfitz/latlong v0.0.0-20140711231157-b74550508561
 	github.com/cznic/fileutil v0.0.0-20180108211300-6a051e75936f // indirect
@@ -47,7 +48,6 @@ require (
 	github.com/rwcarlsen/goexif v0.0.0-20180518182100-8d986c03457a
 	github.com/shurcooL/sanitized_anchor_name v0.0.0-20150515002706-11a20b799bf2 // indirect
 	github.com/smartystreets/goconvey v0.0.0-20190330032615-68dc04aab96a // indirect
-	github.com/stretchr/testify v1.3.0 // indirect
 	github.com/syndtr/goleveldb v0.0.0-20180608030153-db3ee9ee8931
 	github.com/tgulacsi/picago v0.0.0-20171229130838-9e1ac2306c70
 	go4.org v0.0.0-20190218023631-ce4c26f7be8e

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,8 @@ cloud.google.com/go v0.39.0/go.mod h1:rVLT6fkc8chs9sfPtFc1SBH6em7n+ZoXaG+87tDISt
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/FiloSottile/b2 v0.0.0-20170207175032-b197f7a2c317 h1:1GuMjC4tjfwnWBdoTS7YqtQ3JIsEft6NRcdmXdzvYYc=
 github.com/FiloSottile/b2 v0.0.0-20170207175032-b197f7a2c317/go.mod h1:3DBotXAz3n/g1px/orhrK7xBJLjfaJRRrsEAJiUYEtY=
+github.com/NYTimes/gziphandler v1.1.1 h1:ZUDjpQae29j0ryrS0u/B8HZfJBtBQHjqw2rQ2cqUQ3I=
+github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMomdKFjzJNB0c=
 github.com/PuerkitoBio/goquery v1.5.0/go.mod h1:qD2PgZ9lccMbQlc7eEOjaeRlFQON7xY8kdmcsrnKqMg=
 github.com/andybalholm/cascadia v1.0.0/go.mod h1:GsXiBklL0woXo1j/WYWtSYYC4ouU9PqHO0sqidkEA4Y=
 github.com/aws/aws-sdk-go v1.14.31 h1:amhorvKh1zNxo9YCntvA5uDmgw+pCYXOp4xO8WS1oDg=

--- a/pkg/webserver/webserver.go
+++ b/pkg/webserver/webserver.go
@@ -34,11 +34,12 @@ import (
 	"sync"
 	"time"
 
-	"perkeep.org/pkg/webserver/listen"
-
+	"github.com/NYTimes/gziphandler"
 	"go4.org/net/throttle"
 	"go4.org/wkfs"
 	"golang.org/x/net/http2"
+
+	"perkeep.org/pkg/webserver/listen"
 )
 
 const alpnProto = "acme-tls/1" // from golang.org/x/crypto/acme.ALPNProto
@@ -141,7 +142,7 @@ func (s *Server) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		s.printf("Request #%d: %s %s (from %s) ...", n, req.Method, req.RequestURI, req.RemoteAddr)
 		rw = &trackResponseWriter{ResponseWriter: rw}
 	}
-	s.mux.ServeHTTP(rw, req)
+	gziphandler.GzipHandler(s.mux).ServeHTTP(rw, req)
 	if s.verbose {
 		tw := rw.(*trackResponseWriter)
 		s.printf("Request #%d: %s %s = code %d, %d bytes", n, req.Method, req.RequestURI, tw.code, tw.resSize)


### PR DESCRIPTION
Fixes https://github.com/perkeep/perkeep/issues/318. Maybe overkill? This compresses all server responses; that issue suggested compressing only JSON responses.