### PR TITLE
pkg/blobserver/google/cloudstorage: add rate limiting

### DIFF
--- a/pkg/serverinit/genconfig.go
+++ b/pkg/serverinit/genconfig.go
@@ -758,15 +758,18 @@ func (b *lowBuilder) addGoogleCloudStorageConfig(v string) error {
 	isReplica := b.hasPrefix("/bs/")
 	if isReplica {
 		gsPrefix := "/sto-googlecloudstorage/"
-		b.addPrefix(gsPrefix, "storage-googlecloudstorage", args{
-			"bucket":     bucket,
-			"rate_limit": rate,
+		a := args{
+			"bucket": bucket,
 			"auth": map[string]interface{}{
 				"client_id":     clientID,
 				"client_secret": secret,
 				"refresh_token": refreshToken,
 			},
-		})
+		}
+		if rate != "" {
+			a["rate_limit"] = rate
+		}
+		b.addPrefix(gsPrefix, "storage-googlecloudstorage", a)
 
 		b.addPrefix("/sync-to-googlecloudstorage/", "sync", args{
 			"from": "/bs/",

--- a/pkg/types/serverconfig/config.go
+++ b/pkg/types/serverconfig/config.go
@@ -62,7 +62,7 @@ type Config struct {
 	PackRelated        bool   `json:"packRelated,omitempty"`        // use "blobpacked" instead of the default storage (exclusive with PackBlobs)
 	S3                 string `json:"s3,omitempty"`                 // Amazon S3 credentials: access_key_id:secret_access_key:bucket[/optional/dir][:hostname].
 	B2                 string `json:"b2,omitempty"`                 // Backblaze B2 credentials: account_id:application_key:bucket[/optional/dir].
-	GoogleCloudStorage string `json:"googlecloudstorage,omitempty"` // Google Cloud credentials: clientId:clientSecret:refreshToken:bucket[/optional/dir] or ":bucket[/optional/dir/]" for auto on GCE
+	GoogleCloudStorage string `json:"googlecloudstorage,omitempty"` // Google Cloud credentials: clientId:clientSecret:refreshToken:bucket[/optional/dir][:ratelimit] or ":bucket[/optional/dir/]" for auto on GCE
 	GoogleDrive        string `json:"googledrive,omitempty"`        // Google Drive credentials: clientId:clientSecret:refreshToken:parentId.
 	ShareHandler       bool   `json:"shareHandler,omitempty"`       // enable the share handler. If true, and shareHandlerPath is empty then shareHandlerPath will default to "/share/" when generating the low-level config.
 	ShareHandlerPath   string `json:"shareHandlerPath,omitempty"`   // URL prefix for the share handler. If set, overrides shareHandler.


### PR DESCRIPTION
This solves rate-limit-exceeded errors when dumping large numbers of blobs into a Google Cloud Storage backend. The default limit is 1 request per 10ms and can be overridden with the new optional setting `rate_limit`.