### PR TITLE
pkg/blobserver/google/cloudstorage: don't overwrite a blob that's already present

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -62,7 +62,7 @@ require (
 	google.golang.org/api v0.5.0
 	google.golang.org/appengine v1.6.0 // indirect
 	google.golang.org/genproto v0.0.0-20190522204451-c2c4e71fbf69 // indirect
-	google.golang.org/grpc v1.21.0 // indirect
+	google.golang.org/grpc v1.21.0
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 	gopkg.in/ini.v1 v1.42.0 // indirect
 	gopkg.in/mgo.v2 v2.0.0-20160818020120-3f83fa500528


### PR DESCRIPTION
I've been encountering rate-limit-exceeded errors trying to dump a lot of files into a GCS backend (via `pk-mount`).

I thought what I needed was a rate limiter. That's https://github.com/perkeep/perkeep/pull/1285.

But the problem persisted and I discovered that the GCS blobserver was repeatedly re-uploading the same blob over and over (to wit: my PGP public key). So I wrote _this_ PR, to skip uploading a blob if it's already present.

But that's still not good enough to make the rate-limit-exceeded errors go away. I figure this change is still a good one anyway, so here it is while I dig a bit more.