### PR TITLE
pkg/index: delay (even longer) acquiring a write lock in ReceiveBlob

### DIFF
--- a/pkg/index/corpus_test.go
+++ b/pkg/index/corpus_test.go
@@ -30,7 +30,6 @@ import (
 	"perkeep.org/pkg/types/camtypes"
 )
 
-
 func newTestCorpusWithPermanode(t *testing.T) (c *index.Corpus, pn blob.Ref, keyID1, keyID2 string) {
 	c = index.ExpNewCorpus()
 	pn = blob.MustParse("abc-123")
@@ -113,7 +112,6 @@ func newTestCorpusWithPermanode(t *testing.T) (c *index.Corpus, pn blob.Ref, key
 
 	return c, pn, indextest.KeyID, keyID2
 }
-
 
 // TODO(mpl): remove that whole test?
 

--- a/pkg/index/receive.go
+++ b/pkg/index/receive.go
@@ -207,19 +207,6 @@ func (ix *Index) ReceiveBlob(ctx context.Context, blobRef blob.Ref, source io.Re
 	}
 	sbr := blob.SizedRef{Ref: blobRef, Size: uint32(written)}
 
-	ix.Lock()
-	defer ix.Unlock()
-
-	missingDeps := false
-	defer func() {
-		if err == nil {
-			ix.noteBlobIndexed(blobRef)
-			if !missingDeps {
-				ix.removeAllMissingEdges(blobRef)
-			}
-		}
-	}()
-
 	// By default, return immediately if it looks like we already
 	// have indexed this blob before.  But if the user has
 	// CAMLI_REDO_INDEX_ON_RECEIVE set in their environment,
@@ -247,10 +234,26 @@ func (ix *Index) ReceiveBlob(ctx context.Context, blobRef blob.Ref, source io.Re
 		fetcher: ix.blobSource,
 	}
 
+	// Read subsidiary blobs from source before acquiring ix.Lock (also issue 878).
 	mm, err := ix.populateMutationMap(ctx, fetcher, blobRef, sniffer)
 	if debugEnv {
 		log.Printf("index of %v: mm=%v, err=%v", blobRef, mm, err)
 	}
+	// err is checked below
+
+	ix.Lock()
+	defer ix.Unlock()
+
+	missingDeps := false
+	defer func() {
+		if err == nil {
+			ix.noteBlobIndexed(blobRef)
+			if !missingDeps {
+				ix.removeAllMissingEdges(blobRef)
+			}
+		}
+	}()
+
 	if err != nil {
 		if err != errMissingDep {
 			return blob.SizedRef{}, err


### PR DESCRIPTION
Possible fix for #878. Have been running with this change for a little while, haven't seen the deadlock again yet, pretty sure I would have by now. Also, `go test -race ./...` reports no (new) race conditions.