### PR TITLE
Audio file info display and "media" predicate

### DIFF
--- a/pkg/search/predicate.go
+++ b/pkg/search/predicate.go
@@ -121,6 +121,11 @@ func init() {
 	registerKeyword(newIsPortait())
 	registerKeyword(newWidth())
 
+	// MediaTags predicates
+	registerKeyword(newMedia())
+	//registerKeyword(newArtist())
+	//registerKeyword(newAlbum())
+
 	// File predicates
 	registerKeyword(newFilename())
 
@@ -569,6 +574,39 @@ func (h height) Predicate(ctx context.Context, args []string) (*Constraint, erro
 		IsImage: true,
 		Height:  whIntConstraint(mins, maxs),
 	})
+	return c, nil
+}
+
+// MediaTags Predicates
+
+type media struct {
+	matchPrefix
+}
+
+func newMedia() keyword {
+	return media{newMatchPrefix("media")}
+}
+
+func (t media) Description() string {
+	return "match nodes containing substring in their media tags"
+}
+
+func (t media) Predicate(ctx context.Context, args []string) (*Constraint, error) {
+	c := &Constraint{
+		Permanode: &PermanodeConstraint{
+			Attr: nodeattr.CamliContent,
+			ValueInSet: &Constraint{
+				File: &FileConstraint{
+					MediaTag: &MediaTagConstraint{
+						String: &StringConstraint{
+							Contains:				 args[0],
+							CaseInsensitive: true,
+						},
+					},
+				},
+			},
+		},
+	}
 	return c, nil
 }
 

--- a/server/perkeepd/ui/blob_item_audio.css
+++ b/server/perkeepd/ui/blob_item_audio.css
@@ -44,3 +44,7 @@ limitations under the License.
 		color: #5E9ED6;
 	}
 }
+
+.cam-blobitem-audio-trackinfo {
+	opacity: 0.65;
+}

--- a/server/perkeepd/ui/blob_item_audio.css
+++ b/server/perkeepd/ui/blob_item_audio.css
@@ -45,6 +45,15 @@ limitations under the License.
 	}
 }
 
+.cam-blobitem-audio-pause {
+	animation: slow-pulse 1s cubic-bezier(.76,.05,.86,.06) alternate infinite;
+}
+
+@keyframes slow-pulse {
+	0% { opacity: 1 }
+	100% { opacity: 0 }
+}
+
 .cam-blobitem-audio-trackinfo {
 	opacity: 0.65;
 }

--- a/server/perkeepd/ui/blob_item_audio_content.js
+++ b/server/perkeepd/ui/blob_item_audio_content.js
@@ -17,6 +17,7 @@ limitations under the License.
 goog.provide('cam.BlobItemAudioContent');
 
 goog.require('goog.math.Size');
+goog.require('cam.BlobItemGenericContent');
 
 // Renders audio blob items.
 cam.BlobItemAudioContent = React.createClass({
@@ -44,27 +45,19 @@ cam.BlobItemAudioContent = React.createClass({
 				onMouseEnter: this.handleMouseOver_,
 				onMouseLeave: this.handleMouseOut_,
 			},
-			React.DOM.a({
-					className: 'cam-unstyled-button',
-					href: this.props.href
-				},
-				this.getAudio_(),
-				this.getPoster_()
-			),
+			this.getAudio_(),
+			React.createElement(cam.BlobItemGenericContent, {
+				href: this.props.href,
+				size: this.props.size,
+				thumbFAIcon: 'volume-up',
+				// TODO(oac): When server indexes audio and provides a poster image, add it here
+				// thumbSrc: ,
+				// thumbAspect: ,
+				title: this.getTitle_(),
+			}),
+			this.getTrackInfo_(),
 			this.getPlayPauseButton_(),
 		);
-	},
-
-	getPoster_: function() {
-		// TODO(oac): When server indexes audio and provides a poster image, render it here.
-		return React.DOM.i({
-			className: 'fa fa-volume-up',
-			style: {
-				fontSize: this.props.size.height / 1.5 + 'px',
-				lineHeight: this.props.size.height + 'px',
-				width: this.props.size.width,
-			},
-		});
 	},
 
 	getAudio_: function() {
@@ -76,6 +69,25 @@ cam.BlobItemAudioContent = React.createClass({
 				display: 'none',
 			},
 		});
+	},
+
+	getTitle_: function() {
+		var mediaTags = this.props.mediaTags;
+		if (mediaTags) {
+			return mediaTags.title || '[No Title]';
+		} else {
+			return this.props.filename || 'Audio File';
+		}
+	},
+
+	getTrackInfo_: function() {
+		var mediaTags = this.props.mediaTags;
+		if (mediaTags) {
+			return React.DOM.span({
+				className:'cam-blobitem-thumbtitle cam-blobitem-audio-trackinfo',
+				style: { width: this.props.size.width }
+			}, (mediaTags.artist || '[No Artist]') + ' / ' + (mediaTags.album || '[No Album]'));
+		}
 	},
 
 	getPlayPauseButton_: function() {
@@ -174,5 +186,6 @@ cam.BlobItemAudioContent.Handler.prototype.createContent = function(size) {
 		filename: this.rm_.file.fileName,
 		href: this.href_,
 		size: size,
+		mediaTags: this.rm_.mediaTags
 	});
 };

--- a/server/perkeepd/ui/blob_item_audio_content.js
+++ b/server/perkeepd/ui/blob_item_audio_content.js
@@ -91,7 +91,7 @@ cam.BlobItemAudioContent = React.createClass({
 	},
 
 	getPlayPauseButton_: function() {
-		if (!this.state.mouseover) {
+		if (!this.state.playing && !this.state.mouseover) {
 			return null;
 		}
 		return (
@@ -118,7 +118,13 @@ cam.BlobItemAudioContent = React.createClass({
 	},
 
 	setAudioRef_: function(audio) {
-		this.audioRef_ = audio;
+		var self = this;
+		if (audio) {
+			self.audioRef_ = audio;
+			audio.addEventListener('pause', function() {
+				self.setState({ playing: false })
+			})
+		}
 	},
 
 	handlePlayPauseClick_: function(e) {

--- a/server/perkeepd/ui/blob_item_generic_content.js
+++ b/server/perkeepd/ui/blob_item_generic_content.js
@@ -31,8 +31,9 @@ cam.BlobItemGenericContent = React.createClass({
 	propTypes: {
 		href: React.PropTypes.string.isRequired,
 		size: React.PropTypes.instanceOf(goog.math.Size).isRequired,
-		thumbSrc: React.PropTypes.string.isRequired,
-		thumbAspect: React.PropTypes.number.isRequired,
+		thumbSrc: React.PropTypes.string,
+		thumbAspect: React.PropTypes.number,
+		thumbFAIcon: React.PropTypes.string,
 		title: React.PropTypes.string.isRequired,
 	},
 
@@ -55,16 +56,33 @@ cam.BlobItemGenericContent = React.createClass({
 	},
 
 	getThumb_: function(thumbClipSize) {
-		var thumbSize = this.getThumbSize_(thumbClipSize);
-		var pos = cam.math.center(thumbSize, thumbClipSize);
-		return React.DOM.img({
-			className: 'cam-blobitem-thumb',
-			ref: 'thumb',
-			src: this.props.thumbSrc,
-			style: {left:pos.x, top:pos.y},
-			width: thumbSize.width,
-			height: thumbSize.height,
-		})
+		if (this.props.thumbSrc && this.props.thumbAspect) {
+			var thumbSize = this.getThumbSize_(thumbClipSize);
+			var pos = cam.math.center(thumbSize, thumbClipSize);
+			return React.DOM.img({
+				className: 'cam-blobitem-thumb',
+				ref: 'thumb',
+				src: this.props.thumbSrc,
+				style: {left:pos.x, top:pos.y},
+				width: thumbSize.width,
+				height: thumbSize.height,
+			})
+		} else if (this.props.thumbFAIcon) {
+			return React.DOM.div({
+				className: 'cam-blobitem-thumb',
+				width: '100%',
+				height: '100%',
+			}, [
+				React.DOM.i({
+					className: 'fa fa-' + this.props.thumbFAIcon,
+					style: {
+						fontSize: this.props.size.height / 1.5 + 'px',
+						lineHeight: this.props.size.height + 'px',
+						width: this.props.size.width,
+					},
+				})
+			]);
+		}
 	},
 
 	getLabel_: function() {


### PR DESCRIPTION
This PR adds some UI improvements to audio content blobs, and adds a "media" predicate that searches through all tags.

Some context:
I am hacking on the audio file handling a bit as I want to use perkeep to play music from my collection on my phone, and just wanted to share this early on. The next thing I wanted to do is have a central player element instead of a per-file one, so that I can navigate while it's playing.