### PR TITLE
doc/todo: fix link, now on github

### DIFF
--- a/doc/todo/README.md
+++ b/doc/todo/README.md
@@ -1,4 +1,4 @@
 # Contributor Project Ideas
 
-* The [TODO file](https://perkeep.googlesource.com/perkeep/+/master/TODO)
+* The [TODO file](https://github.com/perkeep/perkeep/blob/master/TODO)
 * The [issue tracker](https://github.com/perkeep/perkeep/issues) lists both features and bugs


### PR DESCRIPTION
Fixes #1298
