### PR TITLE
 pkg/blobserver/diskpacked: Let reindex skip over errors and make it concurrent

### DIFF
--- a/cmd/pk/dp_idx_rebuild.go
+++ b/cmd/pk/dp_idx_rebuild.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"errors"
 	"flag"
 	"fmt"
@@ -27,6 +28,7 @@ import (
 	"perkeep.org/internal/osutil"
 	"perkeep.org/pkg/blobserver/diskpacked"
 	"perkeep.org/pkg/cmdmain"
+	"perkeep.org/pkg/env"
 	"perkeep.org/pkg/serverinit"
 )
 
@@ -127,5 +129,8 @@ func (c *reindexdpCmd) RunCommand(args []string) error {
 	}
 	log.Printf("indexConf: %v", indexConf)
 
-	return diskpacked.Reindex(path, c.overwrite, indexConf)
+	ctx := diskpacked.CtxSetVerbose(context.Background(), env.IsDebug())
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	return diskpacked.Reindex(ctx, path, c.overwrite, indexConf)
 }

--- a/pkg/blobserver/diskpacked/dele.go
+++ b/pkg/blobserver/diskpacked/dele.go
@@ -83,14 +83,13 @@ func (s *storage) delete(br blob.Ref) error {
 		if err == nil {
 			return nil
 		}
-		if err != errNoPunch {
+		if !errors.Is(err, errNoPunch) {
 			return err
 		}
-		// err == errNoPunch - not implemented
 	}
 
 	// fill with zero
-	n, err := f.Seek(meta.offset, os.SEEK_SET)
+	n, err := f.Seek(meta.offset, io.SeekStart)
 	if err != nil {
 		return err
 	}

--- a/pkg/blobserver/diskpacked/diskpacked.go
+++ b/pkg/blobserver/diskpacked/diskpacked.go
@@ -168,7 +168,7 @@ func newStorage(root string, maxFileSize int64, indexConf jsonconfig.Obj) (s *st
 		return nil, fmt.Errorf("storage root %q doesn't exist", root)
 	}
 	if err != nil {
-		return nil, fmt.Errorf("Failed to stat directory %q: %w", root, err)
+		return nil, fmt.Errorf("failed to stat directory %q: %w", root, err)
 	}
 	if !fi.IsDir() {
 		return nil, fmt.Errorf("storage root %q exists but is not a directory", root)
@@ -202,7 +202,7 @@ func newStorage(root string, maxFileSize int64, indexConf jsonconfig.Obj) (s *st
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if _, _, err := s.StorageGeneration(); err != nil {
-		return nil, fmt.Errorf("Error initialization generation for %q: %w", root, err)
+		return nil, fmt.Errorf("error initialization generation for %q: %w", root, err)
 	}
 	return s, nil
 }

--- a/pkg/blobserver/diskpacked/diskpacked.go
+++ b/pkg/blobserver/diskpacked/diskpacked.go
@@ -126,12 +126,12 @@ func IsDir(dir string) (bool, error) {
 func New(dir string) (blobserver.Storage, error) {
 	var maxSize int64
 	var n, atMax int
-	if des, err := os.ReadDir(dir); err == nil {
-		// Detect existing max size from size of files, if obvious, and set maxSize to that
-		for _, de := range des {
-			if nm := de.Name(); strings.HasPrefix(nm, "pack-") && strings.HasSuffix(nm, ".blobs") {
-				n++
-				if fi, err := de.Info(); err == nil {
+	if dh, err := os.Open(dir); err == nil {
+		if fis, err := dh.Readdir(-1); err == nil {
+			// Detect existing max size from size of files, if obvious, and set maxSize to that
+			for _, fi := range fis {
+				if nm := fi.Name(); strings.HasPrefix(nm, "pack-") && strings.HasSuffix(nm, ".blobs") {
+					n++
 					if s := fi.Size(); s > maxSize {
 						maxSize, atMax = fi.Size(), 0
 					} else if s == maxSize {

--- a/pkg/blobserver/diskpacked/diskpacked_test.go
+++ b/pkg/blobserver/diskpacked/diskpacked_test.go
@@ -105,7 +105,9 @@ func TestDoubleReceive(t *testing.T) {
 	if size(0) < blobSize {
 		t.Fatalf("size = %d; want at least %d", size(0), blobSize)
 	}
-	sto.(*storage).nextPack()
+	if err = sto.(*storage).nextPack(); err != nil {
+		t.Fatal(err)
+	}
 
 	_, err = blobserver.Receive(ctxbg, sto, br, b.Reader())
 	if err != nil {
@@ -134,7 +136,7 @@ func TestDelete(t *testing.T) {
 		return func() error {
 			sb, err := sto.ReceiveBlob(ctxbg, tb.BlobRef(), tb.Reader())
 			if err != nil {
-				return fmt.Errorf("ReceiveBlob of %s: %v", sb, err)
+				return fmt.Errorf("ReceiveBlob of %s: %w", sb, err)
 			}
 			if sb != tb.SizedRef() {
 				return fmt.Errorf("Received %v; want %v", sb, tb.SizedRef())
@@ -159,7 +161,7 @@ func TestDelete(t *testing.T) {
 	stepDelete := func(tb *test.Blob) step {
 		return func() error {
 			if err := sto.RemoveBlobs(ctx, []blob.Ref{tb.BlobRef()}); err != nil {
-				return fmt.Errorf("RemoveBlob(%s): %v", tb.BlobRef(), err)
+				return fmt.Errorf("RemoveBlob(%s): %w", tb.BlobRef(), err)
 			}
 			return nil
 		}
@@ -223,7 +225,7 @@ func TestDoubleReceiveFailingIndex(t *testing.T) {
 
 	_, err := blobserver.Receive(ctxbg, sto, br, b.Reader())
 	if err != nil {
-		if err != errDummy {
+		if !errors.Is(err, errDummy) {
 			t.Fatal(err)
 		}
 		t.Logf("dummy fail")

--- a/pkg/blobserver/diskpacked/punch_linux.go
+++ b/pkg/blobserver/diskpacked/punch_linux.go
@@ -17,6 +17,7 @@ limitations under the License.
 package diskpacked
 
 import (
+	"errors"
 	"os"
 	"syscall"
 )
@@ -39,7 +40,7 @@ func punchHoleLinux(file *os.File, offset int64, size int64) error {
 	err := syscall.Fallocate(int(file.Fd()),
 		falloc_fl_punch_hole|falloc_fl_keep_size,
 		offset, size)
-	if err == syscall.ENOSYS || err == syscall.EOPNOTSUPP {
+	if errors.Is(err, syscall.ENOSYS) || errors.Is(err, syscall.EOPNOTSUPP) {
 		return errNoPunch
 	}
 	return err

--- a/pkg/blobserver/diskpacked/reindex_test.go
+++ b/pkg/blobserver/diskpacked/reindex_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package diskpacked
 
 import (
+	"context"
 	"testing"
 
 	"perkeep.org/pkg/blob"
@@ -52,7 +53,10 @@ func TestWalkPack(t *testing.T) {
 		return nil
 	}
 
-	if err := s.Walk(nil, walk); err != nil {
+	ctx, cancel := context.WithCancel(context.Background())
+	err := s.Walk(ctx, walk)
+	cancel()
+	if err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
Reindex on GOMAXPROCS pack files concurrently.