### PR TITLE
doc/readme: Updated Link

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -36,7 +36,7 @@ on the [mailing list](https://groups.google.com/group/camlistore).
 * [Terminology](/doc/terms.md):  let's agree on terms to stay sane
 * [Use Cases](/doc/uses.md): what one might do with all this (or at least our aspirations)
 * [Prior Art](/doc/prior-art.md): other projects with similar goals or strategies
-* [Contributing](https://camlistore.org/doc/contributing): how to help
+* [Contributing](/code#contributing): how to help
 * [Style guide](/doc/web-ui-styleguide.md) for the Web UI
 
 


### PR DESCRIPTION
#Issue: 
The link pointing to "camlistore.org" will redirect back to "perkeep.org" anyways, so updated with relative link.
#Change:
Updated "Contributing" link from "https://camlistore.org/doc/contributing" to "/code#contributing".