### PR TITLE
Remove cloud launcher from doc

### DIFF
--- a/doc/compare.md
+++ b/doc/compare.md
@@ -25,11 +25,10 @@ and their investors aren't happy. By paying for keeping your own data,
 you avoid the uncertainty of what other people (companies, investors)
 are going to do to your data.
 
-We do provide the [Cloud Launcher](https://perkeep.org/launch/) to run
-a copy on Google Compute Engine yourself. Perkeep runs happily on
-desktop machines, Raspberry Pis, home servers, Amazon EC2, Google
-Cloud Platform, or any other cloud provider. We suggest using at least
-two for redundancy. Your replicas can sync amongst themselves.
+Perkeep runs happily on desktop machines, Raspberry Pis, home servers,
+Amazon EC2, Google Cloud Platform, or any other cloud provider. 
+We suggest using at least two for redundancy. Your replicas can sync
+amongst themselves.
 
 ## Open source
 

--- a/doc/release/0.10.html
+++ b/doc/release/0.10.html
@@ -49,10 +49,6 @@ $ docker pull gcr.io/perkeep-containers/perkeep:0.10
   <a href="https://play.google.com/store/apps/details?id=org.camlistore">Our Android app</a> has been updated on the Google Play store.
 </p>
 
-<h2>Cloud Launcher</h2>
-
-<p>To deploy a Perkeep server on Google Cloud, see our <a href="https://perkeep.org/launch/">Cloud Launcher</a> utility.</p>
-
 <h2>Downloads</h2>
 
 <center>


### PR DESCRIPTION
Removes cloud launcher documentation.

Cloud launcher was removed in c9f78d02adf9740f3b8d403a1418554293cc9f41