### PR TITLE
storage-examples: grant permissions on the bucket

### DIFF
--- a/doc/storage-examples.md
+++ b/doc/storage-examples.md
@@ -24,6 +24,7 @@ It is advisable to use a dedicated key/secret for Perkeep:
     "Statement": [
         {
             "Resource": [
+                "arn:aws:s3:::YOUR_BUCKET_NAME",
                 "arn:aws:s3:::YOUR_BUCKET_NAME/*"
             ],
             "Sid": "Stmt1464826210000",


### PR DESCRIPTION
Closes #1338 (not 100% certain its the same issue as I had but probably)

Pretty sure this is needed, both from experience and from trying just now:

```
2021/01/01 22:49:52 Caught panic installer handlers: error instantiating storage for prefix "/sto-s3/", type "s3": s3: could not determine endpoint: AccessDenied: Access Denied
```

This has to do with `GetBucketLocation/ListBuckets` that must be granted on the bucket itself and not on the objects.

Cheers,