### PR TITLE
serverinit: two-way sync by default

### DIFF
--- a/pkg/serverinit/genconfig.go
+++ b/pkg/serverinit/genconfig.go
@@ -570,6 +570,19 @@ func (b *lowBuilder) addS3Config(s3 string) error {
 					"file": filepath.Join(b.high.BlobPath, "sync-to-s3-queue."+b.kvFileType()),
 				}),
 		})
+		syncFromS3Dest := "/bs/"
+		if b.runIndex() {
+			syncFromS3Dest = "/bs-and-maybe-also-index/"
+		}
+		b.addPrefix("/sync-from-s3/", "sync", args{
+			"from": s3Prefix,
+			"to":   syncFromS3Dest,
+			"queue": b.thatQueueUnlessMemory(
+				map[string]interface{}{
+					"type": b.kvFileType(),
+					"file": filepath.Join(b.high.BlobPath, "sync-from-s3-queue."+b.kvFileType()),
+				}),
+		})
 		return nil
 	}
 
@@ -644,6 +657,19 @@ func (b *lowBuilder) addB2Config(b2 string) error {
 				map[string]interface{}{
 					"type": b.kvFileType(),
 					"file": filepath.Join(b.high.BlobPath, "sync-to-b2-queue."+b.kvFileType()),
+				}),
+		})
+		syncFromB2Dest := "/bs/"
+		if b.runIndex() {
+			syncFromB2Dest = "/bs-and-maybe-also-index/"
+		}
+		b.addPrefix("/sync-from-b2/", "sync", args{
+			"from": b2Prefix,
+			"to":   syncFromB2Dest,
+			"queue": b.thatQueueUnlessMemory(
+				map[string]interface{}{
+					"type": b.kvFileType(),
+					"file": filepath.Join(b.high.BlobPath, "sync-from-b2-queue."+b.kvFileType()),
 				}),
 		})
 		return nil
@@ -770,6 +796,19 @@ func (b *lowBuilder) addGoogleCloudStorageConfig(v string) error {
 				map[string]interface{}{
 					"type": b.kvFileType(),
 					"file": filepath.Join(b.high.BlobPath, "sync-to-googlecloud-queue."+b.kvFileType()),
+				}),
+		})
+		syncFromGoogleCloudStorageDest := "/bs/"
+		if b.runIndex() {
+			syncFromGoogleCloudStorageDest = "/bs-and-maybe-also-index/"
+		}
+		b.addPrefix("/sync-from-googlecloudstorage/", "sync", args{
+			"from": gsPrefix,
+			"to":   syncFromGoogleCloudStorageDest,
+			"queue": b.thatQueueUnlessMemory(
+				map[string]interface{}{
+					"type": b.kvFileType(),
+					"file": filepath.Join(b.high.BlobPath, "sync-from-googlecloud-queue."+b.kvFileType()),
 				}),
 		})
 		return nil

--- a/pkg/serverinit/testdata/mem-want.json
+++ b/pkg/serverinit/testdata/mem-want.json
@@ -127,6 +127,28 @@
 				"bucket": "bucket"
 			}
 		},
+		"/sync-from-googlecloudstorage/": {
+			"handler": "sync",
+			"handlerArgs": {
+				"from": "/sto-googlecloudstorage/",
+				"queue": {
+					"file": "/tmp/blobs/sync-from-googlecloud-queue.kv",
+					"type": "kv"
+				},
+				"to": "/bs-and-maybe-also-index/"
+			}
+		},
+		"/sync-from-s3/": {
+			"handler": "sync",
+			"handlerArgs": {
+				"from": "/sto-s3/",
+				"queue": {
+					"file": "/tmp/blobs/sync-from-s3-queue.kv",
+					"type": "kv"
+				},
+				"to": "/bs-and-maybe-also-index/"
+			}
+		},
 		"/sync-to-googlecloudstorage/": {
 			"handler": "sync",
 			"handlerArgs": {

--- a/pkg/serverinit/testdata/with_sourceroot-want.json
+++ b/pkg/serverinit/testdata/with_sourceroot-want.json
@@ -104,6 +104,17 @@
 				"bucket": "bucket"
 			}
 		},
+		"/sync-from-s3/": {
+			"handler": "sync",
+			"handlerArgs": {
+				"from": "/sto-s3/",
+				"queue": {
+					"file": "/tmp/blobs/sync-from-s3-queue.kv",
+					"type": "kv"
+				},
+				"to": "/bs-and-maybe-also-index/"
+			}
+		},
 		"/sync-to-s3/": {
 			"handler": "sync",
 			"handlerArgs": {


### PR DESCRIPTION
closes #1331

This makes setting up perkeep on a new computer pretty easy. Paste your config and sync.

I wonder why this wasn't the default, could it be because listing remote objects can take a long time?