### PR TITLE
docs: s3:DeleteObject is not required

### DIFF
--- a/doc/storage-examples.md
+++ b/doc/storage-examples.md
@@ -29,7 +29,6 @@ It is advisable to use a dedicated key/secret for Perkeep:
             "Sid": "Stmt1464826210000",
             "Effect": "Allow",
             "Action": [
-                "s3:DeleteObject",
                 "s3:GetBucketLocation",
                 "s3:GetObject",
                 "s3:ListBucket",


### PR DESCRIPTION
AFAIK this is not needed unless there are things in perkeep that deletes objects?