### PR TITLE
server-config: packRelated doesn't need blobPath

### DIFF
--- a/doc/server-config.md
+++ b/doc/server-config.md
@@ -102,7 +102,7 @@ endpoint instead of AWS S3, such as `my-minio-server.example.com`. A specific
 region may be specified by using [Low-level Configuration](#lowlevel), though
 the bucket's region will generally be detected automatically.
 
-Additionally, there are two mutually exclusive options which only apply if `blobPath` is set:
+Additionally, there are two mutually exclusive options:
 
 * `packRelated`: if true, blobs are automatically repacked for fast read access.
 * `packBlobs`: if true, diskpacked is used instead of the default


### PR DESCRIPTION
AFAIK this was false. `packRelated` affects `s3`, `b2` and `googlecloudstorage`.

It isn't supported on some other storage types like `memoryStorage` or  `googledrive` but it will raise errors so the user will know.