### PR TITLE
b2: document example + point to perkeep/b2 fork

### DIFF
--- a/doc/storage-examples.md
+++ b/doc/storage-examples.md
@@ -6,17 +6,17 @@
 
 To use S3 with Perkeep, you need to:
 
-* Sign up for an Amazon Web Services account
-* Sign into the AWS console, navigate to 'S3'
-* Create an S3 bucket for your Perkeep backups (Perkeep will not work if you put other files in this bucket)
-* Configure your Perkeep server to sync blobs to the S3 bucket
+* Sign up for an Amazon Web Services account.
+* Sign into the AWS console, navigate to 'S3'.
+* Create an S3 bucket for your Perkeep backups (Perkeep will not work if you put other files in this bucket).
+* Configure your Perkeep server to sync blobs to the S3 bucket.
 
 It is advisable to use a dedicated key/secret for Perkeep:
 
-* Sign into the AWS console, navigate to 'Identity & Access Management' and click 'Users'
-* Click 'Create new users' and create a user for Perkeep (keep 'Generate an access key' checked)
+* Sign into the AWS console, navigate to 'Identity & Access Management' and click 'Users'.
+* Click 'Create new users' and create a user for Perkeep (keep 'Generate an access key' checked).
 * Click 'Show User Security Credentials' to get the users Access key and Secret key - these will be required to configure Perkeep and can't be obtained after you leave this screen.
-* Go back to the user list and select the new user, and on the 'permissions' tab add the following 'inline policy' (replacing YOUR_BUCKET_NAME with the name of the bucket you created)
+* Go back to the user list and select the new user, and on the 'permissions' tab add the following 'inline policy' (replacing YOUR_BUCKET_NAME with the name of the bucket you created):
 
 ```
 {
@@ -43,5 +43,29 @@ It is advisable to use a dedicated key/secret for Perkeep:
 
 Finally, add the s3 config line to your Perkeep `server-config.json`:
 ```
-s3: "ACCESS_KEY:SECRET_KEY:YOUR_BUCKET_NAME"
+"s3": "ACCESS_KEY:SECRET_KEY:YOUR_BUCKET_NAME"
+```
+
+## B2
+
+[Backblaze B2](https://www.backblaze.com/b2/cloud-storage.html) is simple, reliable, affordable object storage.
+
+To use b2 with Perkep, you need to:
+* Sign up for a Backblaze account.
+* Sign in to the Backblaze console, navigate to 'Buckets'.
+* Create a bucket for your Perkeep backups (Perkeep will not work if you put other files on this bucket).
+* Configure your perkeep server to sync blobs to the Backblaze bucket.
+
+It is advisable to create a dedicated Application Key for Perkeep:
+
+* Sign in to the Backblaze console, navigate to 'App Keys'.
+* Click 'Add a New Application Key'.
+* Give it a name, for example 'perkeep'.
+* Allow access to the bucket that you just created.
+* Choose 'Read and Write'.
+* Click 'Create New Key'.
+
+Finally, add the b2 config line to your perkeep `server-config.json`:
+```
+"b2": "keyID:applicationKey:bucket"
 ```

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	cloud.google.com/go/datastore v1.1.0
 	cloud.google.com/go/logging v1.1.2
 	cloud.google.com/go/storage v1.10.0
-	github.com/FiloSottile/b2 v0.0.0-20170207175032-b197f7a2c317
+	github.com/FiloSottile/b2 v0.0.0-20170207175032-b197f7a2c317 // indirect
 	github.com/aws/aws-sdk-go v1.14.31
 	github.com/bradfitz/latlong v0.0.0-20170410180902-f3db6d0dff40
 	github.com/cznic/fileutil v0.0.0-20180108211300-6a051e75936f // indirect
@@ -42,6 +42,7 @@ require (
 	github.com/nf/cr2 v0.0.0-20140528043846-05d46fef4f2f
 	github.com/onsi/ginkgo v1.8.0 // indirect
 	github.com/onsi/gomega v1.5.0 // indirect
+	github.com/perkeep/b2 v0.0.0-20180913003434-1ae8d9b78db9
 	github.com/pkg/sftp v1.12.1-0.20200915114829-37434b9e086f
 	github.com/plaid/plaid-go v0.0.0-20161222051224-02b6af68061b
 	github.com/russross/blackfriday v2.0.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -269,6 +269,8 @@ github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1Cpa
 github.com/onsi/gomega v1.5.0 h1:izbySO9zDPmjJ8rDjLvkA2zJHIo+HkYXHnf7eN7SSyo=
 github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
+github.com/perkeep/b2 v0.0.0-20180913003434-1ae8d9b78db9 h1:Wns4DneT6dMNbGPylkKfdU992jsoEL7bvwlnPQ46+fg=
+github.com/perkeep/b2 v0.0.0-20180913003434-1ae8d9b78db9/go.mod h1:wr5gMCoMWNiQbxfI5DTPRtwdTHMHheInIYNljOvo2ZE=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/pkg/blobserver/b2/b2.go
+++ b/pkg/blobserver/b2/b2.go
@@ -32,7 +32,7 @@ import (
 	"perkeep.org/pkg/blobserver/memory"
 	"perkeep.org/pkg/constants"
 
-	"github.com/FiloSottile/b2"
+	"github.com/perkeep/b2"
 	"go4.org/jsonconfig"
 	"go4.org/syncutil"
 )


### PR DESCRIPTION
- Add documentation in storage-examples for using Perkeep with b2 as a
  storage backend. The documentation uses the new API terminology:
  AccountID is no longer a thing in the Backblaze web console.

- Replace FiloSottile/b2 by perkeep/b2 where we host a copy of
  clgillis's Pull Request[1]. We can point to the original project
  again as soon as it is merged.

  Note that I haven't updated the vendor directory and it seems that
 `go mod vendor` updates way more things that are also outdated in the
  master branch, so I will leave that as an exercise to whoever has
  commit access :).

Before this Pull Request, launching the b2 storage would error with the
following error message:
```
Error parsing config: Caught panic: error instantiating storage for prefix "/sto-b2/", type "b2": Post "https://api000.backblazeb2.com/b2api/v1/b2_list_buckets": b2 remote error [bad_request]: accountId invalid
```