### PR TITLE
bytes.md: part must contain BlobRef or BytesRef

### DIFF
--- a/doc/schema/bytes.md
+++ b/doc/schema/bytes.md
@@ -27,6 +27,9 @@ a "file" schema blob.
       //                these in a hash tree.  it is an error if both "bytesRef"
       //                and "blobRef" are specified.
       //
+      //    The absence of "blobRef" or "bytesRef" is used to represent a hole in a
+      //    sparse file. Or just zeros.
+      //
       // Optional:
       //    "offset": the number of bytes into blobRef or bytesRef to skip to
       //              get the necessary bytes for the range. usually zero (unspecified)


### PR DESCRIPTION
I confirmed this by looking at schema.go:

https://github.com/perkeep/perkeep/blob/4b2ae528420fe68a2b95d7d5fc7e3f4490c4d91e/pkg/schema/schema.go#L772

I was wondering what a size-only part could possibly mean.