### PR TITLE
index: small docs improvements

### DIFF
--- a/pkg/index/doc.go
+++ b/pkg/index/doc.go
@@ -37,9 +37,9 @@ for search operations:
 
  * Other:
    "meta:<blobref>" -> "<size>|<mimetype>"
-   "have:<blobref>" -> "<size>" (used for enumeration, which doesn't need mime type)
+   "have:<blobref>" -> "<size>" or "<size>|indexed" (used for enumeration, which doesn't need mime type and for marking indexed blobs)
 
- * For GetOwnerClaims(permanode, signer):
+ * Permanode Claims:
    "claim|<permanode-blobref>|<keyid>|<date>|<claim-blobref>" -> "<URL:type>|<URL:attr>|<URL:value>"
 
 */


### PR DESCRIPTION
Small nits I noticed while reading pkg/index

- Document that we use an '|indexed' suffix in the 'have:' key to mark
  indexed blobs.

- Don't refer to GetOwnerClaims. This method no longer exists and was
  replaced by AppendClaims. Don't bother naming the exact Index
  interface method this key serves but instead focus on explaining what
  information we store in that key.