### PR TITLE
pkg/schema: create CamliType type

### DIFF
--- a/app/publisher/main.go
+++ b/app/publisher/main.go
@@ -55,6 +55,7 @@ import (
 	"perkeep.org/pkg/constants"
 	"perkeep.org/pkg/fileembed"
 	"perkeep.org/pkg/publish"
+	"perkeep.org/pkg/schema"
 	"perkeep.org/pkg/search"
 	"perkeep.org/pkg/server"
 	"perkeep.org/pkg/sorted"
@@ -869,7 +870,7 @@ func (pr *publishRequest) serveSubjectTemplate() {
 	pr.ph.cacheDescribed(res.Meta)
 
 	subdes := res.Meta[pr.subject.String()]
-	if subdes.CamliType == "file" {
+	if subdes.CamliType == schema.TypeFile {
 		pr.serveFileDownload(subdes)
 		return
 	}

--- a/app/publisher/zip.go
+++ b/app/publisher/zip.go
@@ -169,9 +169,9 @@ func (zh *zipHandler) blobsFromDir(dirPath string, dirBlob blob.Ref) ([]*blobFil
 	for _, v := range ent {
 		fullpath := path.Join(dirPath, v.FileName())
 		switch v.CamliType() {
-		case "file":
+		case schema.TypeFile:
 			list = append(list, &blobFile{v.BlobRef(), fullpath})
-		case "directory":
+		case schema.TypeDirectory:
 			children, err := zh.blobsFromDir(fullpath, v.BlobRef())
 			if err != nil {
 				return nil, fmt.Errorf("Could not get list of blobs from %v: %v", v.BlobRef(), err)

--- a/cmd/pk-get/get.go
+++ b/cmd/pk-get/get.go
@@ -240,7 +240,7 @@ func smartFetch(ctx context.Context, src blob.Fetcher, targ string, br blob.Ref)
 	rcc.Close()
 
 	switch b.Type() {
-	case "directory":
+	case schema.TypeDirectory:
 		dir := filepath.Join(targ, b.FileName())
 		if *flagVerbose {
 			log.Printf("Fetching directory %v into %s", br, dir)
@@ -256,7 +256,7 @@ func smartFetch(ctx context.Context, src blob.Fetcher, targ string, br blob.Ref)
 			return fmt.Errorf("bad entries blobref in dir %v", b.BlobRef())
 		}
 		return smartFetch(ctx, src, dir, entries)
-	case "static-set":
+	case schema.TypeStaticSet:
 		if *flagVerbose {
 			log.Printf("Fetching directory entries %v into %s", br, targ)
 		}
@@ -289,7 +289,7 @@ func smartFetch(ctx context.Context, src blob.Fetcher, targ string, br blob.Ref)
 			}
 		}
 		return nil
-	case "file":
+	case schema.TypeFile:
 		fr, err := schema.NewFileReader(ctx, src, br)
 		if err != nil {
 			return fmt.Errorf("NewFileReader: %v", err)
@@ -322,7 +322,7 @@ func smartFetch(ctx context.Context, src blob.Fetcher, targ string, br blob.Ref)
 			log.Print(err)
 		}
 		return nil
-	case "symlink":
+	case schema.TypeSymlink:
 		if *flagSkipIrregular {
 			return nil
 		}
@@ -354,7 +354,7 @@ func smartFetch(ctx context.Context, src blob.Fetcher, targ string, br blob.Ref)
 		// os.Chtimes always dereferences (does not act on the
 		// symlink but its target).
 		return err
-	case "fifo":
+	case schema.TypeFIFO:
 		if *flagSkipIrregular {
 			return nil
 		}
@@ -389,7 +389,7 @@ func smartFetch(ctx context.Context, src blob.Fetcher, targ string, br blob.Ref)
 
 		return nil
 
-	case "socket":
+	case schema.TypeSocket:
 		if *flagSkipIrregular {
 			return nil
 		}
@@ -425,7 +425,7 @@ func smartFetch(ctx context.Context, src blob.Fetcher, targ string, br blob.Ref)
 		return nil
 
 	default:
-		return errors.New("unknown blob type: " + b.Type())
+		return errors.New("unknown blob type: " + string(b.Type()))
 	}
 	panic("unreachable")
 }

--- a/cmd/pk-get/graph.go
+++ b/cmd/pk-get/graph.go
@@ -53,7 +53,7 @@ func (n *node) dotLabel() string {
 	if n.blob == nil {
 		return fmt.Sprintf("%s\n%d bytes", name, n.size)
 	}
-	return name + "\n" + n.blob.Type()
+	return name + "\n" + string(n.blob.Type())
 }
 
 func (n *node) color() string {

--- a/cmd/pk-put/files.go
+++ b/cmd/pk-put/files.go
@@ -391,9 +391,9 @@ func (up *Uploader) uploadNode(ctx context.Context, n *node) (*client.PutResult,
 		// including mode & os.ModeCharDevice
 		fallthrough
 	case mode&os.ModeSocket != 0:
-		bb.SetType("socket")
+		bb.SetType(schema.TypeSocket)
 	case mode&os.ModeNamedPipe != 0: // fifo
-		bb.SetType("fifo")
+		bb.SetType(schema.TypeFIFO)
 	default:
 		return nil, fmt.Errorf("pk-put.files: unsupported file type %v for file %v", mode, n.fullPath)
 	case fi.IsDir():

--- a/cmd/pk-put/put.go
+++ b/cmd/pk-put/put.go
@@ -33,6 +33,7 @@ import (
 	"perkeep.org/pkg/blobserver/dir"
 	"perkeep.org/pkg/client"
 	"perkeep.org/pkg/cmdmain"
+	"perkeep.org/pkg/schema"
 
 	"go4.org/syncutil"
 )
@@ -119,7 +120,7 @@ func initUploader() {
 	uploader = up
 }
 
-func handleResult(what string, pr *client.PutResult, err error) error {
+func handleResult(what schema.CamliType, pr *client.PutResult, err error) error {
 	if err != nil {
 		cmdmain.Errorf("Error putting %s: %s\n", what, err)
 		cmdmain.ExitWithFailure = true

--- a/cmd/pk/list.go
+++ b/cmd/pk/list.go
@@ -28,6 +28,7 @@ import (
 	"perkeep.org/pkg/blob"
 	"perkeep.org/pkg/client"
 	"perkeep.org/pkg/cmdmain"
+	"perkeep.org/pkg/schema"
 	"perkeep.org/pkg/search"
 )
 
@@ -119,7 +120,7 @@ func (c *listCmd) RunCommand(args []string) error {
 				continue
 			}
 
-			if c.camliType == "" || blob.CamliType == c.camliType {
+			if c.camliType == "" || string(blob.CamliType) == c.camliType {
 				detailed := detail(blob)
 				if detailed != "" {
 					detailed = fmt.Sprintf("\t%v", detailed)
@@ -167,8 +168,8 @@ func (c *listCmd) setClient() error {
 
 func detail(blob *search.DescribedBlob) string {
 	// TODO(mpl): attrType, value for claim. but I don't think they're accessible just with a describe req.
-	if blob.CamliType == "file" {
+	if blob.CamliType == schema.TypeFile {
 		return fmt.Sprintf("%v (%v size=%v)", blob.CamliType, blob.File.FileName, blob.File.Size)
 	}
-	return blob.CamliType
+	return string(blob.CamliType)
 }

--- a/cmd/pk/makestatic.go
+++ b/cmd/pk/makestatic.go
@@ -79,7 +79,7 @@ func (c *makeStaticCmd) RunCommand(args []string) error {
 		return err
 	}
 
-	camliType := func(ref string) string {
+	camliType := func(ref string) schema.CamliType {
 		m := res.Meta[ref]
 		if m == nil {
 			return ""

--- a/pkg/blobserver/blobpacked/blobpacked.go
+++ b/pkg/blobserver/blobpacked/blobpacked.go
@@ -956,7 +956,7 @@ func (s *storage) ReceiveBlob(ctx context.Context, br blob.Ref, source io.Reader
 	size := uint32(buf.Len())
 	isFile := false
 	fileBlob, err := schema.BlobFromReader(br, bytes.NewReader(buf.Bytes()))
-	if err == nil && fileBlob.Type() == "file" {
+	if err == nil && fileBlob.Type() == schema.TypeFile {
 		isFile = true
 	}
 	meta, err := s.getMetaRow(br)

--- a/pkg/client/upload.go
+++ b/pkg/client/upload.go
@@ -464,7 +464,7 @@ func (c *Client) UploadFile(ctx context.Context, filename string, contents io.Re
 			fileMap.SetModTime(modTime)
 		}
 	}
-	fileMap.SetType("file")
+	fileMap.SetType(schema.TypeFile)
 
 	var wholeRef []blob.Ref
 	if opts != nil && opts.WholeRef.Valid() {

--- a/pkg/fs/fs.go
+++ b/pkg/fs/fs.go
@@ -194,7 +194,7 @@ func (n *node) Open(ctx context.Context, req *fuse.OpenRequest, res *fuse.OpenRe
 		Logger.Printf("open of %v: %v", n.blobref, err)
 		return nil, fuse.EIO
 	}
-	if ss.Type() == "directory" {
+	if ss.Type() == schema.TypeDirectory {
 		return n, nil
 	}
 	fr, err := ss.NewFileReader(n.fs.fetcher)
@@ -304,13 +304,13 @@ func (n *node) populateAttr() error {
 	}
 
 	switch meta.Type() {
-	case "file":
+	case schema.TypeFile:
 		n.attr.Size = uint64(meta.PartsSize())
 		n.attr.Blocks = 0 // TODO: set?
 		n.attr.Mode |= 0400
-	case "directory":
+	case schema.TypeDirectory:
 		n.attr.Mode |= 0500
-	case "symlink":
+	case schema.TypeSymlink:
 		n.attr.Mode |= 0400
 	default:
 		Logger.Printf("unknown attr ss.Type %q in populateAttr", meta.Type())
@@ -371,12 +371,12 @@ func (fs *CamliFileSystem) newNodeFromBlobRef(root blob.Ref) (fusefs.Node, error
 	}
 
 	switch blob.Type() {
-	case "directory":
+	case schema.TypeDirectory:
 		n := &node{fs: fs, blobref: root, meta: blob}
 		n.populateAttr()
 		return n, nil
 
-	case "permanode":
+	case schema.TypePermanode:
 		// other mutDirs listed in the default fileystem have names and are displayed
 		return &mutDir{fs: fs, permanode: root, name: "-"}, nil
 	}

--- a/pkg/index/index.go
+++ b/pkg/index/index.go
@@ -1533,7 +1533,7 @@ func (x *Index) EdgesTo(ref blob.Ref, opts *camtypes.EdgesToOpts) (edges []*camt
 			continue
 		}
 		edge.To = ref
-		if edge.FromType == "permanode" {
+		if edge.FromType == schema.TypePermanode {
 			permanodeParents[edge.From.String()] = edge
 		} else {
 			edges = append(edges, edge)
@@ -1569,7 +1569,7 @@ func kvEdgeBackward(k, v string) (edge *camtypes.Edge, ok bool) {
 	}
 	return &camtypes.Edge{
 		From:      parentRef,
-		FromType:  valPart[0],
+		FromType:  schema.CamliType(valPart[0]),
 		FromTitle: valPart[1],
 		BlobRef:   blobRef,
 	}, true
@@ -1771,16 +1771,16 @@ var camliTypeMIMEPrefixBytes = []byte(camliTypeMIMEPrefix)
 
 // "application/json; camliType=file" => "file"
 // "image/gif" => ""
-func camliTypeFromMIME(mime string) string {
+func camliTypeFromMIME(mime string) schema.CamliType {
 	if v := strings.TrimPrefix(mime, camliTypeMIMEPrefix); v != mime {
-		return v
+		return schema.CamliType(v)
 	}
 	return ""
 }
 
-func camliTypeFromMIME_bytes(mime []byte) string {
+func camliTypeFromMIME_bytes(mime []byte) schema.CamliType {
 	if v := bytes.TrimPrefix(mime, camliTypeMIMEPrefixBytes); len(v) != len(mime) {
-		return strutil.StringFromBytes(v)
+		return schema.CamliType(strutil.StringFromBytes(v))
 	}
 	return ""
 }

--- a/pkg/index/indextest/tests.go
+++ b/pkg/index/indextest/tests.go
@@ -686,7 +686,7 @@ func Index(t *testing.T, initIdx func() *index.Index) {
 		if err != nil {
 			t.Errorf("GetBlobMeta(%q) = %v", pn, err)
 		} else {
-			if e := "permanode"; meta.CamliType != e {
+			if e := schema.TypePermanode; meta.CamliType != e {
 				t.Errorf("GetBlobMeta(%q) mime = %q, want %q", pn, meta.CamliType, e)
 			}
 			if meta.Size == 0 {

--- a/pkg/index/receive.go
+++ b/pkg/index/receive.go
@@ -336,11 +336,11 @@ func (ix *Index) populateMutationMap(ctx context.Context, fetcher *missTrackFetc
 	var err error
 	if blob, ok := sniffer.SchemaBlob(); ok {
 		switch blob.Type() {
-		case "claim":
+		case schema.TypeClaim:
 			err = ix.populateClaim(ctx, fetcher, blob, mm)
-		case "file":
+		case schema.TypeFile:
 			err = ix.populateFile(ctx, fetcher, blob, mm)
-		case "directory":
+		case schema.TypeDirectory:
 			err = ix.populateDir(ctx, fetcher, blob, mm)
 		}
 	}
@@ -827,14 +827,12 @@ func (ix *Index) populateDeleteClaim(ctx context.Context, cl schema.Claim, vr *j
 		return nil
 	}
 
-	// TODO(mpl): create consts somewhere for "claim" and "permanode" as camliTypes, and use them,
-	// instead of hardcoding. Unless they already exist ? (didn't find them).
-	if meta.CamliType != "permanode" && meta.CamliType != "claim" {
+	if meta.CamliType != schema.TypePermanode && meta.CamliType != schema.TypeClaim {
 		log.Print(fmt.Errorf("delete claim target in %v is neither a permanode nor a claim: %v", br, meta.CamliType))
 		return nil
 	}
 	mm.Set(keyDeleted.Key(target, cl.ClaimDateString(), br), "")
-	if meta.CamliType == "claim" {
+	if meta.CamliType == schema.TypeClaim {
 		return nil
 	}
 	recentKey := keyRecentPermanode.Key(vr.SignerKeyId, cl.ClaimDateString(), br)

--- a/pkg/index/sniff.go
+++ b/pkg/index/sniff.go
@@ -32,7 +32,7 @@ type BlobSniffer struct {
 	written   int64
 	meta      *schema.Blob // or nil
 	mimeType  string
-	camliType string
+	camliType schema.CamliType
 }
 
 func NewBlobSniffer(ref blob.Ref) *BlobSniffer {
@@ -87,12 +87,12 @@ func (sn *BlobSniffer) Body() ([]byte, error) {
 // the form "application/json; camliType=foo".
 func (sn *BlobSniffer) MIMEType() string { return sn.mimeType }
 
-func (sn *BlobSniffer) CamliType() string { return sn.camliType }
+func (sn *BlobSniffer) CamliType() schema.CamliType { return sn.camliType }
 
 func (sn *BlobSniffer) Parse() {
 	if sn.bufferIsCamliJSON() {
 		sn.camliType = sn.meta.Type()
-		sn.mimeType = "application/json; camliType=" + sn.camliType
+		sn.mimeType = "application/json; camliType=" + string(sn.camliType)
 	} else {
 		sn.mimeType = magic.MIMEType(sn.contents)
 	}

--- a/pkg/schema/fileread_test.go
+++ b/pkg/schema/fileread_test.go
@@ -144,7 +144,7 @@ func skipBytes(fr *FileReader, skipBytes uint64) uint64 {
 func TestReader(t *testing.T) {
 	for idx, rt := range readTests {
 		ss := new(superset)
-		ss.Type = "file"
+		ss.Type = TypeFile
 		ss.Version = 1
 		ss.Parts = rt.parts
 		fr, err := ss.NewFileReader(testFetcher)

--- a/pkg/schema/filewriter.go
+++ b/pkg/schema/filewriter.go
@@ -173,7 +173,7 @@ func uploadBytes(ctx context.Context, bs blobserver.StatReceiver, bb *Builder, s
 	// the "file" schema before any of its parts arrive, then the indexer
 	// can get confused.  So wait on the parts before, and then upload
 	// the "file" blob afterwards.
-	if bb.Type() == "file" {
+	if bb.Type() == TypeFile {
 		future.errc <- nil
 		_, err := future.Get() // may not be nil, if children parts failed
 		future = newUploadBytesFuture()

--- a/pkg/schema/schema_test.go
+++ b/pkg/schema/schema_test.go
@@ -553,7 +553,7 @@ func TestStaticFileAndStaticSymlink(t *testing.T) {
 	}
 
 	bb := NewCommonFileMap(fd.Name(), fi)
-	bb.SetType("file")
+	bb.SetType(TypeFile)
 	bb.SetFileName(fd.Name())
 	blob := bb.Blob()
 
@@ -592,7 +592,7 @@ func TestStaticFileAndStaticSymlink(t *testing.T) {
 	}
 
 	bb = NewCommonFileMap(src, fi)
-	bb.SetType("symlink")
+	bb.SetType(TypeSymlink)
 	bb.SetFileName(src)
 	bb.SetSymlinkTarget(target)
 	blob = bb.Blob()
@@ -638,7 +638,7 @@ func TestStaticFIFO(t *testing.T) {
 	}
 
 	bb := NewCommonFileMap(fifoPath, fi)
-	bb.SetType("fifo")
+	bb.SetType(TypeFIFO)
 	bb.SetFileName(fifoPath)
 	blob := bb.Blob()
 	t.Logf("Got JSON for fifo: %s\n", blob.JSON())
@@ -675,7 +675,7 @@ func TestStaticSocket(t *testing.T) {
 	}
 
 	bb := NewCommonFileMap(sockPath, fi)
-	bb.SetType("socket")
+	bb.SetType(TypeSocket)
 	bb.SetFileName(sockPath)
 	blob := bb.Blob()
 	t.Logf("Got JSON for socket: %s\n", blob.JSON())

--- a/pkg/search/describe.go
+++ b/pkg/search/describe.go
@@ -34,6 +34,7 @@ import (
 	"go4.org/types"
 	"perkeep.org/internal/httputil"
 	"perkeep.org/pkg/blob"
+	"perkeep.org/pkg/schema"
 	"perkeep.org/pkg/types/camtypes"
 )
 
@@ -223,9 +224,9 @@ type MetaMap map[string]*DescribedBlob
 type DescribedBlob struct {
 	Request *DescribeRequest `json:"-"`
 
-	BlobRef   blob.Ref `json:"blobRef"`
-	CamliType string   `json:"camliType,omitempty"`
-	Size      int64    `json:"size,"`
+	BlobRef   blob.Ref         `json:"blobRef"`
+	CamliType schema.CamliType `json:"camliType,omitempty"`
+	Size      int64            `json:"size,"`
 
 	// if camliType "permanode"
 	Permanode *DescribedPermanode `json:"permanode,omitempty"`
@@ -739,7 +740,7 @@ func (dr *DescribeRequest) doDescribe(ctx context.Context, br blob.Ref, depth in
 	// maps.  Then add JSON marhsallers to those types. Add tests.
 	des := dr.describedBlob(br)
 	if meta.CamliType != "" {
-		des.setMIMEType("application/json; camliType=" + meta.CamliType)
+		des.setMIMEType("application/json; camliType=" + string(meta.CamliType))
 	}
 	des.Size = int64(meta.Size)
 
@@ -907,6 +908,6 @@ func (dr *DescribeRequest) describeRefs(ctx context.Context, str string, depth i
 
 func (b *DescribedBlob) setMIMEType(mime string) {
 	if strings.HasPrefix(mime, camliTypePrefix) {
-		b.CamliType = strings.TrimPrefix(mime, camliTypePrefix)
+		b.CamliType = schema.CamliType(strings.TrimPrefix(mime, camliTypePrefix))
 	}
 }

--- a/pkg/search/handler.go
+++ b/pkg/search/handler.go
@@ -39,6 +39,7 @@ import (
 	"perkeep.org/pkg/blobserver"
 	"perkeep.org/pkg/index"
 	"perkeep.org/pkg/jsonsign"
+	"perkeep.org/pkg/schema"
 	"perkeep.org/pkg/types/camtypes"
 	"perkeep.org/pkg/types/serverconfig"
 )
@@ -504,8 +505,8 @@ type EdgesResponse struct {
 
 // An EdgeItem is an item returned from $searchRoot/camli/search/edgesto.
 type EdgeItem struct {
-	From     blob.Ref `json:"from"`
-	FromType string   `json:"fromType"`
+	From     blob.Ref         `json:"from"`
+	FromType schema.CamliType `json:"fromType"`
 }
 
 var testHookBug121 = func() {}
@@ -808,14 +809,14 @@ func (h *Handler) EdgesTo(req *EdgesRequest) (*EdgesResponse, error) {
 		if found {
 			ei = &EdgeItem{
 				From:     edge.From,
-				FromType: "permanode",
+				FromType: schema.TypePermanode,
 			}
 		}
 		resc <- edgeOrError{edge: ei}
 	}
 	verifying := 0
 	for _, edge := range edges {
-		if edge.FromType == "permanode" {
+		if edge.FromType == schema.TypePermanode {
 			verifying++
 			go verify(edge)
 			continue

--- a/pkg/search/query.go
+++ b/pkg/search/query.go
@@ -35,6 +35,7 @@ import (
 
 	"perkeep.org/pkg/blob"
 	"perkeep.org/pkg/index"
+	"perkeep.org/pkg/schema"
 	"perkeep.org/pkg/types/camtypes"
 
 	"context"
@@ -294,9 +295,9 @@ type Constraint struct {
 	// Anything, if true, matches all blobs.
 	Anything bool `json:"anything,omitempty"`
 
-	CamliType     string `json:"camliType,omitempty"`    // camliType of the JSON blob
-	AnyCamliType  bool   `json:"anyCamliType,omitempty"` // if true, any camli JSON blob matches
-	BlobRefPrefix string `json:"blobRefPrefix,omitempty"`
+	CamliType     schema.CamliType `json:"camliType,omitempty"`    // camliType of the JSON blob
+	AnyCamliType  bool             `json:"anyCamliType,omitempty"` // if true, any camli JSON blob matches
+	BlobRefPrefix string           `json:"blobRefPrefix,omitempty"`
 
 	File *FileConstraint `json:"file,omitempty"`
 	Dir  *DirConstraint  `json:"dir,omitempty"`
@@ -383,7 +384,7 @@ func (c *Constraint) matchesAtMostOneBlob() blob.Ref {
 }
 
 func (c *Constraint) onlyMatchesPermanode() bool {
-	if c.Permanode != nil || c.CamliType == "permanode" {
+	if c.Permanode != nil || c.CamliType == schema.TypePermanode {
 		return true
 	}
 
@@ -1455,7 +1456,7 @@ func (q *SearchQuery) pickCandidateSource(s *search) (src candidateSource) {
 		if c.matchesFileByWholeRef() {
 			src.name = "corpus_file_meta"
 			src.send = func(ctx context.Context, s *search, fn func(camtypes.BlobMeta) bool) error {
-				corpus.EnumerateCamliBlobs("file", fn)
+				corpus.EnumerateCamliBlobs(schema.TypeFile, fn)
 				return nil
 			}
 			return
@@ -1679,7 +1680,7 @@ func (c *PermanodeConstraint) hasValueConstraint() bool {
 }
 
 func (c *PermanodeConstraint) blobMatches(ctx context.Context, s *search, br blob.Ref, bm camtypes.BlobMeta) (ok bool, err error) {
-	if bm.CamliType != "permanode" {
+	if bm.CamliType != schema.TypePermanode {
 		return false, nil
 	}
 	corpus := s.h.corpus
@@ -2085,7 +2086,7 @@ func (c *Constraint) fileOrDirOrLogicalMatches(ctx context.Context, s *search, b
 }
 
 func (c *DirConstraint) blobMatches(ctx context.Context, s *search, br blob.Ref, bm camtypes.BlobMeta) (bool, error) {
-	if bm.CamliType != "directory" {
+	if bm.CamliType != schema.TypeDirectory {
 		return false, nil
 	}
 	// TODO(mpl): I've added c.BlobRefPrefix, so that c.ParentDir can be directly

--- a/pkg/search/websocket.go
+++ b/pkg/search/websocket.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
+	"perkeep.org/pkg/schema"
 )
 
 const (
@@ -51,7 +52,7 @@ type wsHub struct {
 	register       chan *wsConn
 	unregister     chan *wsConn
 	watchReq       chan watchReq
-	newBlobRecv    chan string // new blob received. string is camliType.
+	newBlobRecv    chan schema.CamliType // new blob received.
 	updatedResults chan *watchedQuery
 	statusUpdate   chan json.RawMessage
 
@@ -66,7 +67,7 @@ func newWebsocketHub(sh *Handler) *wsHub {
 		unregister:     make(chan *wsConn), // unbuffered; issue 563
 		conns:          make(map[*wsConn]bool),
 		watchReq:       make(chan watchReq, buffered),
-		newBlobRecv:    make(chan string, buffered),
+		newBlobRecv:    make(chan schema.CamliType, buffered),
 		updatedResults: make(chan *watchedQuery, buffered),
 		statusUpdate:   make(chan json.RawMessage, buffered),
 	}

--- a/pkg/server/filetree.go
+++ b/pkg/server/filetree.go
@@ -37,7 +37,7 @@ type FileTreeNode struct {
 	Name string `json:"name"`
 	// Type is the camliType of the node. This may be "file", "directory", "symlink"
 	// or other in the future.
-	Type string `json:"type"`
+	Type schema.CamliType `json:"type"`
 	// BlobRef is the blob.Ref of the node.
 	BlobRef blob.Ref `json:"blobRef"`
 }

--- a/pkg/server/import_share.go
+++ b/pkg/server/import_share.go
@@ -167,7 +167,7 @@ func (si *shareImporter) imprt(ctx context.Context, br blob.Ref) error {
 		return nil
 	// TODO(mpl): other camliTypes, at least symlink.
 	default:
-		return errors.New("unknown blob type: " + b.Type())
+		return errors.New("unknown blob type: " + string(b.Type()))
 	}
 }
 

--- a/pkg/server/share.go
+++ b/pkg/server/share.go
@@ -324,7 +324,7 @@ func bytesHaveSchemaLink(br blob.Ref, bb []byte, target blob.Ref) bool {
 	}
 	typ := b.Type()
 	switch typ {
-	case "file", "bytes":
+	case schema.TypeFile, schema.TypeBytes:
 		for _, bp := range b.ByteParts() {
 			if bp.BlobRef.Valid() {
 				if bp.BlobRef == target {
@@ -337,11 +337,11 @@ func bytesHaveSchemaLink(br blob.Ref, bb []byte, target blob.Ref) bool {
 				}
 			}
 		}
-	case "directory":
+	case schema.TypeDirectory:
 		if d, ok := b.DirectoryEntries(); ok {
 			return d == target
 		}
-	case "static-set":
+	case schema.TypeStaticSet:
 		for _, m := range b.StaticSetMembers() {
 			if m == target {
 				return true

--- a/pkg/types/camtypes/search.go
+++ b/pkg/types/camtypes/search.go
@@ -27,6 +27,7 @@ import (
 
 	"perkeep.org/internal/magic"
 	"perkeep.org/pkg/blob"
+	"perkeep.org/pkg/schema"
 
 	"go4.org/types"
 )
@@ -196,8 +197,8 @@ type EdgesToOpts struct {
 
 type Edge struct {
 	From      blob.Ref
-	FromType  string // "permanode", "directory", etc
-	FromTitle string // name of source permanode or directory
+	FromType  schema.CamliType // "permanode", "directory", etc
+	FromTitle string           // name of source permanode or directory
 	To        blob.Ref
 	BlobRef   blob.Ref // the blob responsible for the edge relationship
 }
@@ -214,7 +215,7 @@ type BlobMeta struct {
 
 	// CamliType is non-empty if this blob is a Perkeep JSON
 	// schema blob. If so, this is its "camliType" attribute.
-	CamliType string
+	CamliType schema.CamliType
 
 	// TODO(bradfitz): change CamliTypethis *string to save 8 bytes
 }


### PR DESCRIPTION
    pkg/schema: create CamliType type
    
    Create a CamliType type in pkg/schema and use it in a couple of
    packages.
    
    It can be implemented in other packages as we go.


I was reading pkg/index and decided to implement @mpl's TODO:
```
// TODO(mpl): create consts somewhere for "claim" and "permanode" as camliTypes, and use them,		if meta.CamliType != string(schema.PermanodeCamliType) && meta.CamliType != string(schema.ClaimCamliType) {
// instead of hardcoding. Unless they already exist ? (didn't find them).
```