### PR TITLE
pk-put+perkeepd config: support fingerprints

### DIFF
--- a/pkg/jsonsign/keys.go
+++ b/pkg/jsonsign/keys.go
@@ -119,7 +119,9 @@ func EntityFromSecring(keyID, keyFile string) (*openpgp.Entity, error) {
 	var entity *openpgp.Entity
 	for _, e := range el {
 		pk := e.PrivateKey
-		if pk == nil || (pk.KeyIdString() != keyID && pk.KeyIdShortString() != keyID) {
+		if pk == nil || (keyID != fmt.Sprintf("%X", pk.Fingerprint) &&
+			pk.KeyIdString() != keyID &&
+			pk.KeyIdShortString() != keyID) {
 			continue
 		}
 		entity = e
@@ -131,7 +133,7 @@ func EntityFromSecring(keyID, keyFile string) (*openpgp.Entity, error) {
 			if pk == nil {
 				continue
 			}
-			found = append(found, pk.KeyIdShortString())
+			found = append(found, pk.KeyIdString())
 		}
 		return nil, fmt.Errorf("didn't find a key in %q for keyID %q; other keyIDs in file = %v", keyFile, keyID, found)
 	}

--- a/pkg/serverinit/genconfig.go
+++ b/pkg/serverinit/genconfig.go
@@ -190,7 +190,7 @@ func (b *lowBuilder) searchOwner() (owner *serverconfig.Owner, err error) {
 }
 
 // longIdentity returns the long form (16 chars) of the GPG key ID, in case the
-// user provided the short form (8 chars) in the config.
+// user provided the short form (8 chars) or the fingerprint (40 chars) in the config.
 func (b *lowBuilder) longIdentity() (string, error) {
 	if b.high.Identity == "" {
 		return "", errNoOwner
@@ -200,6 +200,9 @@ func (b *lowBuilder) longIdentity() (string, error) {
 	}
 	if len(b.high.Identity) == 16 {
 		return b.high.Identity, nil
+	}
+	if len(b.high.Identity) == 40 {
+		return b.high.Identity[24:], nil
 	}
 	if b.high.IdentitySecretRing == "" {
 		return "", errNoOwner

--- a/pkg/serverinit/testdata/gpg_fingerprint-want.json
+++ b/pkg/serverinit/testdata/gpg_fingerprint-want.json
@@ -1,0 +1,122 @@
+{
+	"auth": "userpass:camlistore:pass3179",
+	"https": false,
+	"listen": "localhost:3179",
+	"prefixes": {
+		"/": {
+			"handler": "root",
+			"handlerArgs": {
+				"blobRoot": "/bs-and-maybe-also-index/",
+				"helpRoot": "/help/",
+				"jsonSignRoot": "/sighelper/",
+				"ownerName": "Alice",
+				"searchRoot": "/my-search/",
+				"shareRoot": "/share/",
+				"statusRoot": "/status/",
+				"stealth": false
+			}
+		},
+		"/bs-and-index/": {
+			"handler": "storage-replica",
+			"handlerArgs": {
+				"backends": [
+					"/bs/",
+					"/index/"
+				]
+			}
+		},
+		"/bs-and-maybe-also-index/": {
+			"handler": "storage-cond",
+			"handlerArgs": {
+				"read": "/bs/",
+				"write": {
+					"else": "/bs/",
+					"if": "isSchema",
+					"then": "/bs-and-index/"
+				}
+			}
+		},
+		"/bs/": {
+			"handler": "storage-filesystem",
+			"handlerArgs": {
+				"path": "/tmp/blobs"
+			}
+		},
+		"/cache/": {
+			"handler": "storage-filesystem",
+			"handlerArgs": {
+				"path": "/tmp/blobs/cache"
+			}
+		},
+		"/help/": {
+			"handler": "help"
+		},
+		"/importer/": {
+			"handler": "importer",
+			"handlerArgs": {}
+		},
+		"/index/": {
+			"handler": "storage-index",
+			"handlerArgs": {
+				"blobSource": "/bs/",
+				"storage": {
+					"file": "/path/to/indexkv.db",
+					"type": "kv"
+				}
+			}
+		},
+		"/my-search/": {
+			"handler": "search",
+			"handlerArgs": {
+				"index": "/index/",
+				"owner": {
+					"identity": "2931A67C26F5ABDA",
+					"secringFile": "/path/to/secring"
+				},
+				"slurpToMemory": true
+			}
+		},
+		"/setup/": {
+			"handler": "setup"
+		},
+		"/share/": {
+			"handler": "share",
+			"handlerArgs": {
+				"blobRoot": "/bs/",
+				"index": "/index/"
+			}
+		},
+		"/sighelper/": {
+			"handler": "jsonsign",
+			"handlerArgs": {
+				"keyId": "2931A67C26F5ABDA",
+				"publicKeyDest": "/bs-and-index/",
+				"secretRing": "/path/to/secring"
+			}
+		},
+		"/status/": {
+			"handler": "status"
+		},
+		"/sync/": {
+			"handler": "sync",
+			"handlerArgs": {
+				"from": "/bs/",
+				"queue": {
+					"file": "/tmp/blobs/sync-to-index-queue.kv",
+					"type": "kv"
+				},
+				"to": "/index/"
+			}
+		},
+		"/ui/": {
+			"handler": "ui",
+			"handlerArgs": {
+				"cache": "/cache/",
+				"scaledImage": {
+					"file": "/tmp/blobs/thumbmeta.kv",
+					"type": "kv"
+				}
+			}
+		}
+	}
+}

--- a/pkg/serverinit/testdata/gpg_fingerprint.json
+++ b/pkg/serverinit/testdata/gpg_fingerprint.json
@@ -1,0 +1,10 @@
+{
+	"listen": "localhost:3179",
+	"auth": "userpass:camlistore:pass3179",
+	"blobPath": "/tmp/blobs",
+	"kvIndexFile": "/path/to/indexkv.db",
+	"identity": "FBB89AA320A2806FE497C0492931A67C26F5ABDA",
+	"identitySecretRing": "/path/to/secring",
+	"ownerName": "Alice",
+	"shareHandlerPath": "/share/"
+}


### PR DESCRIPTION
closes #1361

```
    pk-put+perkeepd config: support fingerprints
    
    - Key ids in the `0xXXXXXXXXXXXXXXXX` format are now accepted.
    
    - Key ids in the `02A6 ACA0 5F16 9329 D94A  FFB8 C804 D0BA 9F70 883D`
      format are also accepted. With or without spaces.
    
    - Help texts now use long keyids so that its clear that we support
      them.
```