### PR TITLE
signer: deprecate KeyId()

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -1438,13 +1438,12 @@ func (c *Client) uploadPublicKey(ctx context.Context) error {
 // checkMatchingKeys compares the client's and the server's keys and logs if they differ.
 func (c *Client) checkMatchingKeys() {
 	serverKey, err := c.ServerKeyID()
-	// The server provides the full (16 digit) key fingerprint but schema.Signer only stores
-	// the short (8 digit) key ID.
-	if err == nil && len(serverKey) >= 8 {
-		shortServerKey := serverKey[len(serverKey)-8:]
-		if shortServerKey != c.signer.KeyID() {
-			log.Printf("Warning: client (%s) and server (%s) keys differ.", c.signer.KeyID(), shortServerKey)
-		}
+	if err != nil {
+		log.Printf("Warning: Could not obtain ther server's key id: %v", err)
+		return
+	}
+	if serverKey != c.signer.KeyIDLong() {
+		log.Printf("Warning: client (%s) and server (%s) keys differ.", c.signer.KeyIDLong(), serverKey)
 	}
 }
 

--- a/pkg/jsonsign/keys.go
+++ b/pkg/jsonsign/keys.go
@@ -38,39 +38,21 @@ const publicKeyMaxSize = 256 * 1024
 
 // ParseArmoredPublicKey tries to parse an armored public key from r,
 // taking care to bound the amount it reads.
-// The returned shortKeyId is 8 capital hex digits.
+// The returned fingerprint is 40 capital hex digits.
 // The returned armoredKey is a copy of the contents read.
-func ParseArmoredPublicKey(r io.Reader) (shortKeyId, armoredKey string, err error) {
+func ParseArmoredPublicKey(r io.Reader) (fingerprint, armoredKey string, err error) {
 	var buf bytes.Buffer
 	pk, err := openArmoredPublicKeyFile(ioutil.NopCloser(io.TeeReader(r, &buf)))
 	if err != nil {
 		return
 	}
-	return publicKeyID(pk), buf.String(), nil
+	return fingerprintString(pk), buf.String(), nil
 }
 
-func VerifyPublicKeyFile(file, keyid string) (bool, error) {
-	f, err := wkfs.Open(file)
-	if err != nil {
-		return false, err
-	}
-
-	key, err := openArmoredPublicKeyFile(f)
-	if err != nil {
-		return false, err
-	}
-	keyID := publicKeyID(key)
-	if keyID != strings.ToUpper(keyid) {
-		return false, fmt.Errorf("Key in file %q has id %q; expected %q",
-			file, keyID, keyid)
-	}
-	return true, nil
-}
-
-// publicKeyID returns the short (8 character) capital hex GPG key ID
-// of the provided public key.
-func publicKeyID(pubKey *packet.PublicKey) string {
-	return fmt.Sprintf("%X", pubKey.Fingerprint[len(pubKey.Fingerprint)-4:])
+// fingerprintString returns the fingerprint (40 characters) capital hex GPG
+// key ID of the provided public key.
+func fingerprintString(pubKey *packet.PublicKey) string {
+	return fmt.Sprintf("%X", pubKey.Fingerprint)
 }
 
 func openArmoredPublicKeyFile(reader io.ReadCloser) (*packet.PublicKey, error) {


### PR DESCRIPTION
Noticed this while working on https://github.com/perkeep/perkeep/pull/1363.

I think we should use fingerprints as much as possible and revert to shorter ids only when necessary, possibly fully deprecating short ids if that is possible. This PR is one step towards this. I intend to open a couple of follow-up PRs improving on this, propagating fingerprints where it makes sense and using them as much as possible.

```
    signer: deprecate KeyId()
    
    `signer.KeyId()` was only used in a counter-productive way
    by comparing it with half of a long ID.
    
    Also use this opportunity to return the full fingerprint from
    ParseArmoredPublicKey. NewSigner was the only caller of this
    function.
```