### PR TITLE
haveImageID: `-f` -> `--format`

### DIFF
--- a/internal/images/docker.go
+++ b/internal/images/docker.go
@@ -66,7 +66,7 @@ func haveDocker() bool {
 }
 
 func haveImageID(name, id string) (ok bool, err error) {
-	out, err := exec.Command("docker", "inspect", "-f", "{{.Id}}", name).Output()
+	out, err := exec.Command("docker", "inspect", "--format", "{{.Id}}", name).Output()
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
    haveImageID: `-f` -> `--format`
    
    Ethier this has never worked or the Docker CLI's API has changed. The
    current meaning of the `-f` flag is filter, not format.

For me this restores thumbnails in the web interface for HEIC images, as I don't have a recent version of imagemagick on my machine.