### PR TITLE
Dockerfile: build using gomodules

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,13 +20,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		libc6-dev \
 		make \
 		pkg-config \
-                libsqlite3-dev
+		libsqlite3-dev
 
-ENV GOLANG_VERSION 1.15.3
+ENV GOLANG_VERSION 1.15.7
 
 WORKDIR /usr/local
 RUN wget -O go.tgz https://dl.google.com/go/go${GOLANG_VERSION}.linux-amd64.tar.gz
-RUN echo "010a88df924a81ec21b293b5da8f9b11c176d27c0ee3962dc1738d2352d3c02d go.tgz" | sha256sum -c -
+RUN echo "0d142143794721bb63ce6c8a6180c4062bcf8ef4715e7d6d6609f3a8282629b3 go.tgz" | sha256sum -c -
 RUN tar -zxvf go.tgz
 
 ENV GOROOT /usr/local/go
@@ -49,10 +49,11 @@ ADD doc /go/src/perkeep.org/doc
 ADD internal /go/src/perkeep.org/internal
 ADD pkg /go/src/perkeep.org/pkg
 ADD server /go/src/perkeep.org/server
-ADD vendor /go/src/perkeep.org/vendor
 ADD website /go/src/perkeep.org/website
 ADD make.go /go/src/perkeep.org/make.go
 ADD VERSION /go/src/perkeep.org/VERSION
+ADD go.mod /go/src/perkeep.org/go.mod
+ADD go.sum /go/src/perkeep.org/go.sum
 
 WORKDIR /go/src/perkeep.org
 


### PR DESCRIPTION
Closes https://github.com/perkeep/perkeep/issues/1372

    Dockerfile: build using gomodules
    
    - Don't ADD the vendor/ directory
    - ADD go.mod and go.sum
    - Bump Go to 1.15.7
    - Style improvement: spaces -> tabs
