### PR TITLE
fs: don't cause io errors on missing blobrefs

### DIFF
--- a/pkg/fs/root.go
+++ b/pkg/fs/root.go
@@ -135,7 +135,11 @@ func (n *root) Lookup(ctx context.Context, name string) (fs.Node, error) {
 
 	if br, ok := blob.Parse(name); ok {
 		Logger.Printf("Root lookup of blobref. %q => %v", name, br)
-		return &node{fs: n.fs, blobref: br}, nil
+		node := &node{fs: n.fs, blobref: br}
+		if _, err := node.schema(); os.IsNotExist(err) {
+			return nil, fuse.ENOENT
+		}
+		return node, nil
 	}
 	Logger.Printf("Bogus root lookup of %q", name)
 	return nil, fuse.ENOENT

--- a/pkg/test/world.go
+++ b/pkg/test/world.go
@@ -311,6 +311,15 @@ func (w *World) NewPermanode(t *testing.T) blob.Ref {
 	return br
 }
 
+func (w *World) PutFile(t *testing.T, name string) blob.Ref {
+	out := MustRunCmd(t, w.Cmd("pk-put", "file", name))
+	br, ok := blob.Parse(strings.TrimSpace(out))
+	if !ok {
+		t.Fatalf("Expected blobref in pk-put stdout; got %q", out)
+	}
+	return br
+}
+
 func (w *World) Cmd(binary string, args ...string) *exec.Cmd {
 	return w.CmdWithEnv(binary, os.Environ(), args...)
 }


### PR DESCRIPTION
    fs: don't cause io errors on missing blobrefs
    
    - Looking up missing blobrefs would cause fs errors. Instead, simply
      return fuse.ENOENT.
    
    - Add tests for:
       * validating that the mountpoint/<blobref> lookups work
    
       * validating that the mountpount/<blobref> lookups don't fail when
         the blob does not exist.
