### PR TITLE
make codebase go-vet-clean

### DIFF
--- a/.github/workflows/tests-lint.yaml
+++ b/.github/workflows/tests-lint.yaml
@@ -1,5 +1,5 @@
 on: [push, pull_request]
-name: "tests/fmt"
+name: "tests/lint"
 
 jobs:
   test:
@@ -29,3 +29,4 @@ jobs:
       run: |
         go fmt ./...
         test -z "$(git status --porcelain)"
+        go vet ./...

--- a/cmd/pk-get/get.go
+++ b/cmd/pk-get/get.go
@@ -28,6 +28,7 @@ import (
 	"path/filepath"
 
 	"go4.org/types"
+
 	"perkeep.org/internal/osutil"
 	"perkeep.org/pkg/blob"
 	"perkeep.org/pkg/buildinfo"
@@ -289,6 +290,7 @@ func smartFetch(ctx context.Context, src blob.Fetcher, targ string, br blob.Ref)
 			}
 		}
 		return nil
+
 	case schema.TypeFile:
 		fr, err := schema.NewFileReader(ctx, src, br)
 		if err != nil {
@@ -322,6 +324,7 @@ func smartFetch(ctx context.Context, src blob.Fetcher, targ string, br blob.Ref)
 			log.Print(err)
 		}
 		return nil
+
 	case schema.TypeSymlink:
 		if *flagSkipIrregular {
 			return nil
@@ -386,7 +389,6 @@ func smartFetch(ctx context.Context, src blob.Fetcher, targ string, br blob.Ref)
 		if err := setFileMeta(name, b); err != nil {
 			log.Print(err)
 		}
-
 		return nil
 
 	case schema.TypeSocket:
@@ -421,13 +423,11 @@ func smartFetch(ctx context.Context, src blob.Fetcher, targ string, br blob.Ref)
 		if err := setFileMeta(name, b); err != nil {
 			log.Print(err)
 		}
-
 		return nil
 
 	default:
 		return errors.New("unknown blob type: " + string(b.Type()))
 	}
-	panic("unreachable")
 }
 
 func setFileMeta(name string, blob *schema.Blob) error {

--- a/cmd/pk-put/discard.go
+++ b/cmd/pk-put/discard.go
@@ -31,7 +31,7 @@ type discardStorage struct {
 
 func (discardStorage) ReceiveBlob(ctx context.Context, br blob.Ref, r io.Reader) (sb blob.SizedRef, err error) {
 	n, err := io.Copy(ioutil.Discard, r)
-	return blob.SizedRef{br, uint32(n)}, err
+	return blob.SizedRef{Ref: br, Size: uint32(n)}, err
 }
 
 func (discardStorage) StatBlobs(ctx context.Context, blobs []blob.Ref, fn func(blob.SizedRef) error) error {

--- a/cmd/pk-put/kvcache.go
+++ b/cmd/pk-put/kvcache.go
@@ -87,7 +87,7 @@ func maybeRunCompaction(dbname string, db *leveldb.DB) error {
 	if nbFiles < 4 {
 		return nil
 	}
-	if err := db.CompactRange(util.Range{nil, nil}); err != nil {
+	if err := db.CompactRange(util.Range{Start: nil, Limit: nil}); err != nil {
 		return fmt.Errorf("could not run compaction on %v's LevelDB: %v", dbname, err)
 	}
 	return nil

--- a/cmd/pk/list.go
+++ b/cmd/pk/list.go
@@ -156,7 +156,7 @@ func (c *listCmd) RunCommand(args []string) error {
 func (c *listCmd) setClient() error {
 	ss, err := c.syncCmd.storageFromParam("src", c.syncCmd.src)
 	if err != nil {
-		fmt.Errorf("Could not set client for describe requests: %v", err)
+		return fmt.Errorf("Could not set client for describe requests: %v", err)
 	}
 	var ok bool
 	c.cl, ok = ss.(*client.Client)

--- a/internal/netutil/ident.go
+++ b/internal/netutil/ident.go
@@ -258,5 +258,4 @@ func uidFromProcReader(lip net.IP, lport int, rip net.IP, rport int, r io.Reader
 			return uid, err
 		}
 	}
-	panic("unreachable")
 }

--- a/pkg/blobserver/b2/b2.go
+++ b/pkg/blobserver/b2/b2.go
@@ -75,8 +75,7 @@ func newFromConfig(_ blobserver.Loader, config jsonconfig.Obj) (blobserver.Stora
 		dirPrefix += "/"
 	}
 
-	t := &http.Transport{}
-	*t = *http.DefaultTransport.(*http.Transport)
+	t := http.DefaultTransport.(*http.Transport).Clone()
 	t.MaxIdleConnsPerHost = 50 // we do delete bursts
 	httpClient := &http.Client{Transport: t}
 	cl, err := b2.NewClient(accountID, appKey, httpClient)

--- a/pkg/blobserver/blobhub_test.go
+++ b/pkg/blobserver/blobhub_test.go
@@ -73,12 +73,12 @@ func TestHubFiring(t *testing.T) {
 	blob1 := blob.MustParse("sha1-0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33")
 	blobsame := blob.MustParse("sha1-0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33")
 
-	hub.NotifyBlobReceived(blob.SizedRef{blob1, 123}) // no-op
+	hub.NotifyBlobReceived(blob.SizedRef{Ref: blob1, Size: 123}) // no-op
 
 	hub.RegisterListener(ch)
 	hub.RegisterBlobListener(blob1, bch)
 
-	hub.NotifyBlobReceived(blob.SizedRef{blobsame, 456})
+	hub.NotifyBlobReceived(blob.SizedRef{Ref: blobsame, Size: 456})
 
 	tmr1 := time.NewTimer(1 * time.Second)
 	select {

--- a/pkg/blobserver/blobpacked/blobpacked_test.go
+++ b/pkg/blobserver/blobpacked/blobpacked_test.go
@@ -747,7 +747,7 @@ func TestSmallFallback(t *testing.T) {
 		log:   test.NewLogger(t, "blobpacked: "),
 	}
 	s.init()
-	b1 := &test.Blob{"foo"}
+	b1 := &test.Blob{Contents: "foo"}
 	b1.MustUpload(t, small)
 	wantSB := b1.SizedRef()
 
@@ -994,8 +994,8 @@ func TestPackerBoundarySplits(t *testing.T) {
 	const sizeAB = 12 << 20
 	const maxBlobSize = 16 << 20
 	bytesAB := randBytes(sizeAB)
-	blobA := &test.Blob{string(bytesAB[:sizeAB/2])}
-	blobB := &test.Blob{string(bytesAB[sizeAB/2:])}
+	blobA := &test.Blob{Contents: string(bytesAB[:sizeAB/2])}
+	blobB := &test.Blob{Contents: string(bytesAB[sizeAB/2:])}
 	refA := blobA.BlobRef()
 	refB := blobB.BlobRef()
 	bytesCFull := randBytes(maxBlobSize - sizeAB) // will be sliced down

--- a/pkg/blobserver/blobpacked/stream_test.go
+++ b/pkg/blobserver/blobpacked/stream_test.go
@@ -44,7 +44,7 @@ func TestStreamBlobs(t *testing.T) {
 	all := map[blob.Ref]bool{}
 	const nBlobs = 10
 	for i := 0; i < nBlobs; i++ {
-		b := &test.Blob{strconv.Itoa(i)}
+		b := &test.Blob{Contents: strconv.Itoa(i)}
 		b.MustUpload(t, small)
 		all[b.BlobRef()] = true
 	}
@@ -131,7 +131,7 @@ func testStreamBlobs(t *testing.T,
 func populateLoose(t *testing.T, s *storage) (wants []storagetest.StreamerTestOpt) {
 	const nBlobs = 10
 	for i := 0; i < nBlobs; i++ {
-		(&test.Blob{strconv.Itoa(i)}).MustUpload(t, s)
+		(&test.Blob{Contents: strconv.Itoa(i)}).MustUpload(t, s)
 	}
 	return append(wants, storagetest.WantN(nBlobs))
 }

--- a/pkg/blobserver/encrypt/encrypt_test.go
+++ b/pkg/blobserver/encrypt/encrypt_test.go
@@ -129,7 +129,7 @@ func TestBadPass(t *testing.T) {
 	for i := range ts.sto.key {
 		ts.sto.key[i] = 0
 	}
-	tb := &test.Blob{"foo"}
+	tb := &test.Blob{Contents: "foo"}
 	mustPanic(t, "no passphrase set", func() { tb.MustUpload(t, ts.sto) })
 }
 
@@ -137,7 +137,7 @@ func TestEncrypt(t *testing.T) {
 	ts := newTestStorage()
 
 	const blobData = "foofoofoo"
-	tb := &test.Blob{blobData}
+	tb := &test.Blob{Contents: blobData}
 	tb.MustUpload(t, ts.sto)
 	if got := ts.fetchOrErrorString(tb.BlobRef()); got != blobData {
 		t.Errorf("Fetching plaintext blobref %v = %v; want %q", tb.BlobRef(), got, blobData)
@@ -159,14 +159,14 @@ func TestEncrypt(t *testing.T) {
 	}
 
 	const blobData2 = "bar"
-	tb2 := &test.Blob{blobData2}
+	tb2 := &test.Blob{Contents: blobData2}
 	tb2.MustUpload(t, ts.sto)
 	if got := ts.fetchOrErrorString(tb2.BlobRef()); got != blobData2 {
 		t.Errorf("Fetching plaintext blobref %v = %v; want %q", tb2.BlobRef(), got, blobData2)
 	}
 
 	missingError := "Error: file does not exist"
-	tb3 := &test.Blob{"xxx"}
+	tb3 := &test.Blob{Contents: "xxx"}
 	if got := ts.fetchOrErrorString(tb3.BlobRef()); got != missingError {
 		t.Errorf("Fetching missing blobref %v; want %q", got, missingError)
 	}
@@ -209,10 +209,10 @@ func TestEncrypt(t *testing.T) {
 func TestLoadMeta(t *testing.T) {
 	ts := newTestStorage()
 	const blobData = "foo"
-	tb := &test.Blob{blobData}
+	tb := &test.Blob{Contents: blobData}
 	tb.MustUpload(t, ts.sto)
 	const blobData2 = "bar"
-	tb2 := &test.Blob{blobData2}
+	tb2 := &test.Blob{Contents: blobData2}
 	tb2.MustUpload(t, ts.sto)
 	meta, blobs := ts.meta, ts.blobs
 

--- a/pkg/blobserver/files/enumerate_test.go
+++ b/pkg/blobserver/files/enumerate_test.go
@@ -53,9 +53,9 @@ func TestEnumerate(t *testing.T) {
 
 	// For test simplicity foo, bar, and baz all have ascending
 	// sha1s and lengths.
-	foo := &test.Blob{"foo"}   // 0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33
-	bar := &test.Blob{"baar"}  // b23361951dde70cb3eca44c0c674181673a129dc
-	baz := &test.Blob{"bazzz"} // e0eb17003ce1c2812ca8f19089fff44ca32b3710
+	foo := &test.Blob{Contents: "foo"}   // 0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33
+	bar := &test.Blob{Contents: "baar"}  // b23361951dde70cb3eca44c0c674181673a129dc
+	baz := &test.Blob{Contents: "bazzz"} // e0eb17003ce1c2812ca8f19089fff44ca32b3710
 	foo.MustUpload(t, ds)
 	bar.MustUpload(t, ds)
 	baz.MustUpload(t, ds)
@@ -135,7 +135,7 @@ func TestEnumerateIsSorted(t *testing.T) {
 	const blobsToMake = 250
 	t.Logf("Uploading test blobs...")
 	for i := 0; i < blobsToMake; i++ {
-		blob := &test.Blob{fmt.Sprintf("blob-%d", i)}
+		blob := &test.Blob{Contents: fmt.Sprintf("blob-%d", i)}
 		blob.MustUpload(t, ds)
 	}
 

--- a/pkg/blobserver/google/drive/enumerate.go
+++ b/pkg/blobserver/google/drive/enumerate.go
@@ -30,5 +30,4 @@ func (sto *driveStorage) MaxEnumerate() int { return 1000 }
 func (sto *driveStorage) EnumerateBlobs(ctx context.Context, dest chan<- blob.SizedRef, after string, limit int) error {
 	defer close(dest)
 	panic("not implemented")
-	return nil
 }

--- a/pkg/blobserver/handlers/upload.go
+++ b/pkg/blobserver/handlers/upload.go
@@ -227,8 +227,8 @@ func handleMultiPartUpload(rw http.ResponseWriter, req *http.Request, blobReceiv
 		var tooBig int64 = blobserver.MaxBlobSize + 1
 		var readBytes int64
 		blobGot, err := blobserver.Receive(ctx, blobReceiver, ref, &readerutil.CountingReader{
-			io.LimitReader(mimePart, tooBig),
-			&readBytes,
+			Reader: io.LimitReader(mimePart, tooBig),
+			N:      &readBytes,
 		})
 		if readBytes == tooBig {
 			err = fmt.Errorf("blob over the limit of %d bytes", blobserver.MaxBlobSize)

--- a/pkg/blobserver/localdisk/localdisk_test.go
+++ b/pkg/blobserver/localdisk/localdisk_test.go
@@ -57,7 +57,7 @@ func NewStorage(t *testing.T) *DiskStorage {
 func TestUploadDup(t *testing.T) {
 	ds := NewStorage(t)
 	defer cleanUp(ds)
-	tb := &test.Blob{"Foo"}
+	tb := &test.Blob{Contents: "Foo"}
 	tb.MustUpload(t, ds)
 	tb.MustUpload(t, ds)
 }
@@ -66,7 +66,7 @@ func TestReceiveStat(t *testing.T) {
 	ds := NewStorage(t)
 	defer cleanUp(ds)
 
-	tb := &test.Blob{"Foo"}
+	tb := &test.Blob{Contents: "Foo"}
 	tb.MustUpload(t, ds)
 
 	ctx := context.Background()
@@ -88,8 +88,8 @@ func TestMultiStat(t *testing.T) {
 	ds := NewStorage(t)
 	defer cleanUp(ds)
 
-	blobfoo := &test.Blob{"foo"}
-	blobbar := &test.Blob{"bar!"}
+	blobfoo := &test.Blob{Contents: "foo"}
+	blobbar := &test.Blob{Contents: "bar!"}
 	blobfoo.MustUpload(t, ds)
 	blobbar.MustUpload(t, ds)
 
@@ -131,7 +131,7 @@ func TestMultiStat(t *testing.T) {
 func TestMissingGetReturnsNoEnt(t *testing.T) {
 	ds := NewStorage(t)
 	defer cleanUp(ds)
-	foo := &test.Blob{"foo"}
+	foo := &test.Blob{Contents: "foo"}
 
 	blob, _, err := ds.Fetch(context.Background(), foo.BlobRef())
 	if err != os.ErrNotExist {

--- a/pkg/blobserver/memory/mem.go
+++ b/pkg/blobserver/memory/mem.go
@@ -168,7 +168,7 @@ func (s *Storage) ReceiveBlob(ctx context.Context, br blob.Ref, source io.Reader
 			}
 		}
 	}
-	return blob.SizedRef{br, uint32(len(all))}, nil
+	return blob.SizedRef{Ref: br, Size: uint32(len(all))}, nil
 }
 
 func (s *Storage) StatBlobs(ctx context.Context, blobs []blob.Ref, fn func(blob.SizedRef) error) error {
@@ -177,7 +177,7 @@ func (s *Storage) StatBlobs(ctx context.Context, blobs []blob.Ref, fn func(blob.
 		b, ok := s.m[br]
 		s.mu.RUnlock()
 		if ok {
-			if err := fn(blob.SizedRef{br, uint32(len(b))}); err != nil {
+			if err := fn(blob.SizedRef{Ref: br, Size: uint32(len(b))}); err != nil {
 				return err
 			}
 		}
@@ -208,7 +208,7 @@ func (s *Storage) EnumerateBlobs(ctx context.Context, dest chan<- blob.SizedRef,
 			continue
 		}
 		select {
-		case dest <- blob.SizedRef{br, uint32(len(s.m[br]))}:
+		case dest <- blob.SizedRef{Ref: br, Size: uint32(len(s.m[br]))}:
 		case <-ctx.Done():
 			return ctx.Err()
 		}

--- a/pkg/blobserver/memory/mem_test.go
+++ b/pkg/blobserver/memory/mem_test.go
@@ -37,26 +37,26 @@ func TestStreamer(t *testing.T) {
 	s := new(memory.Storage)
 	phrases := []string{"foo", "bar", "baz", "quux"}
 	for _, str := range phrases {
-		(&test.Blob{str}).MustUpload(t, s)
+		(&test.Blob{Contents: str}).MustUpload(t, s)
 	}
 	storagetest.TestStreamer(t, s, storagetest.WantN(len(phrases)))
 }
 
 func TestCache(t *testing.T) {
 	c := memory.NewCache(1024)
-	(&test.Blob{"foo"}).MustUpload(t, c)
+	(&test.Blob{Contents: "foo"}).MustUpload(t, c)
 	if got, want := c.SumBlobSize(), int64(3); got != want {
 		t.Errorf("size = %d; want %d", got, want)
 	}
-	(&test.Blob{"bar"}).MustUpload(t, c)
+	(&test.Blob{Contents: "bar"}).MustUpload(t, c)
 	if got, want := c.SumBlobSize(), int64(6); got != want {
 		t.Errorf("size = %d; want %d", got, want)
 	}
-	(&test.Blob{strings.Repeat("x", 1020)}).MustUpload(t, c)
+	(&test.Blob{Contents: strings.Repeat("x", 1020)}).MustUpload(t, c)
 	if got, want := c.SumBlobSize(), int64(1023); got != want {
 		t.Errorf("size = %d; want %d", got, want)
 	}
-	(&test.Blob{"five!"}).MustUpload(t, c)
+	(&test.Blob{Contents: "five!"}).MustUpload(t, c)
 	if got, want := c.SumBlobSize(), int64(5); got != want {
 		t.Errorf("size = %d; want %d", got, want)
 	}

--- a/pkg/blobserver/mergedenum_test.go
+++ b/pkg/blobserver/mergedenum_test.go
@@ -158,7 +158,7 @@ func (te testEnum) EnumerateBlobs(ctx context.Context, dest chan<- blob.SizedRef
 			continue
 		}
 		br := blob.MustParse(bs)
-		dest <- blob.SizedRef{br, 1}
+		dest <- blob.SizedRef{Ref: br, Size: 1}
 		done++
 		if done == limit {
 			break

--- a/pkg/blobserver/multistream_test.go
+++ b/pkg/blobserver/multistream_test.go
@@ -57,7 +57,7 @@ func TestStaticStreamer(t *testing.T) {
 	var blobs []*blob.Blob
 	var want []blob.SizedRef
 	for i := 0; i < 5; i++ {
-		tb := &test.Blob{strconv.Itoa(i)}
+		tb := &test.Blob{Contents: strconv.Itoa(i)}
 		b := tb.Blob()
 		blobs = append(blobs, b)
 		want = append(want, b.SizedRef())
@@ -75,7 +75,7 @@ func TestMultiStreamer(t *testing.T) {
 		var blobs []*blob.Blob
 		for i := 0; i < 3; i++ {
 			n++
-			tb := &test.Blob{strconv.Itoa(n)}
+			tb := &test.Blob{Contents: strconv.Itoa(n)}
 			b := tb.Blob()
 			want = append(want, b.SizedRef()) // overall
 			blobs = append(blobs, b)          // this sub-streamer

--- a/pkg/blobserver/namespace/ns.go
+++ b/pkg/blobserver/namespace/ns.go
@@ -86,7 +86,7 @@ func (ns *nsto) EnumerateBlobs(ctx context.Context, dest chan<- blob.SizedRef, a
 			continue
 		}
 		select {
-		case dest <- blob.SizedRef{br, uint32(size)}:
+		case dest <- blob.SizedRef{Ref: br, Size: uint32(size)}:
 		case <-done:
 			return ctx.Err()
 		}
@@ -131,7 +131,7 @@ func (ns *nsto) ReceiveBlob(ctx context.Context, br blob.Ref, src io.Reader) (sb
 
 	// Check if a duplicate blob, already uploaded previously.
 	if _, ierr := ns.inventory.Get(br.String()); ierr == nil {
-		return blob.SizedRef{br, uint32(size)}, nil
+		return blob.SizedRef{Ref: br, Size: uint32(size)}, nil
 	}
 
 	sb, err = ns.master.ReceiveBlob(ctx, br, &buf)
@@ -165,7 +165,7 @@ func (ns *nsto) StatBlobs(ctx context.Context, blobs []blob.Ref, fn func(blob.Si
 		if err != nil {
 			log.Printf("Bogus namespace key %q / value %q", br.String(), invSizeStr)
 		}
-		if err := fn(blob.SizedRef{br, uint32(invSize)}); err != nil {
+		if err := fn(blob.SizedRef{Ref: br, Size: uint32(invSize)}); err != nil {
 			return err
 		}
 	}

--- a/pkg/blobserver/proxycache/proxycache_test.go
+++ b/pkg/blobserver/proxycache/proxycache_test.go
@@ -104,7 +104,7 @@ func TestEviction(t *testing.T) {
 func TestMissingGetReturnsNoEnt(t *testing.T) {
 	px, ds := NewProxiedDisk(t)
 	defer cleanUp(ds)
-	foo := &test.Blob{"foo"}
+	foo := &test.Blob{Contents: "foo"}
 
 	blob, _, err := px.Fetch(ctxbg, foo.BlobRef())
 	if err != os.ErrNotExist {

--- a/pkg/blobserver/shard/shard_test.go
+++ b/pkg/blobserver/shard/shard_test.go
@@ -59,8 +59,8 @@ func TestShardBasic(t *testing.T) {
 }
 
 func TestShard(t *testing.T) {
-	thingA := &test.Blob{"thing A"} // sha224-2b18a3b52a7211954fb97145cf50a29a6e189a6443f7f1e0fa4529f9, shard 1
-	thingB := &test.Blob{"thing B"} // sha224-f19faf56e53a22bc6f84595b5533e943c98d263b232131881f6ace8f, shard 0
+	thingA := &test.Blob{Contents: "thing A"} // sha224-2b18a3b52a7211954fb97145cf50a29a6e189a6443f7f1e0fa4529f9, shard 1
+	thingB := &test.Blob{Contents: "thing B"} // sha224-f19faf56e53a22bc6f84595b5533e943c98d263b232131881f6ace8f, shard 0
 
 	ts := newTestStorage(t)
 

--- a/pkg/blobserver/stats/statreceiver.go
+++ b/pkg/blobserver/stats/statreceiver.go
@@ -82,7 +82,7 @@ func (sr *Receiver) ReceiveRef(br blob.Ref, size int64) (sb blob.SizedRef, err e
 		sr.Have = make(map[blob.Ref]int64)
 	}
 	sr.Have[br] = size
-	return blob.SizedRef{br, uint32(size)}, nil
+	return blob.SizedRef{Ref: br, Size: uint32(size)}, nil
 }
 
 func (sr *Receiver) StatBlobs(ctx context.Context, blobs []blob.Ref, fn func(blob.SizedRef) error) error {
@@ -90,7 +90,7 @@ func (sr *Receiver) StatBlobs(ctx context.Context, blobs []blob.Ref, fn func(blo
 	sr.Lock()
 	for _, br := range blobs {
 		if size, ok := sr.Have[br]; ok {
-			sized = append(sized, blob.SizedRef{br, uint32(size)})
+			sized = append(sized, blob.SizedRef{Ref: br, Size: uint32(size)})
 		}
 	}
 	sr.Unlock()

--- a/pkg/blobserver/stats/statreceiver_test.go
+++ b/pkg/blobserver/stats/statreceiver_test.go
@@ -28,9 +28,9 @@ import (
 func TestStats(t *testing.T) {
 	ctx := context.Background()
 	st := &Receiver{}
-	foo := test.Blob{"foo"}
-	bar := test.Blob{"bar"}
-	foobar := test.Blob{"foobar"}
+	foo := test.Blob{Contents: "foo"}
+	bar := test.Blob{Contents: "bar"}
+	foobar := test.Blob{Contents: "foobar"}
 
 	foo.MustUpload(t, st)
 	bar.MustUpload(t, st)

--- a/pkg/blobserver/storagetest/storagetest.go
+++ b/pkg/blobserver/storagetest/storagetest.go
@@ -82,7 +82,7 @@ func TestOpt(t *testing.T, opt Opts) {
 
 	t.Logf("Test stat of blob not existing")
 	{
-		b := &test.Blob{"not exist"}
+		b := &test.Blob{Contents: "not exist"}
 		blobRefs := []blob.Ref{b.BlobRef()}
 		testStat(t, sto, blobRefs, nil)
 	}
@@ -100,7 +100,7 @@ func TestOpt(t *testing.T, opt Opts) {
 
 	t.Logf("Testing receive")
 	for i, x := range contents {
-		b1 := &test.Blob{x}
+		b1 := &test.Blob{Contents: x}
 		if testing.Short() {
 			t.Logf("blob[%d] = %s: %q", i, b1.BlobRef(), x)
 		}
@@ -198,7 +198,7 @@ func (r *run) testSubFetcher() {
 		return
 	}
 	t.Logf("Testing SubFetch")
-	big := &test.Blob{"Some big blob"}
+	big := &test.Blob{Contents: "Some big blob"}
 	if _, err := sto.ReceiveBlob(context.Background(), big.BlobRef(), big.Reader()); err != nil {
 		t.Fatal(err)
 	}
@@ -523,6 +523,7 @@ func TestStreamer(t *testing.T, bs blobserver.BlobStreamer, opts ...StreamerTest
 	contToken := ""
 	for i := 0; i < len(wantRefs); i++ {
 		ctx, cancel := context.WithCancel(context.TODO())
+		defer cancel()
 		ch := make(chan blobserver.BlobAndToken)
 		errc := make(chan error, 1)
 		go func() {

--- a/pkg/blobserver/sync_test.go
+++ b/pkg/blobserver/sync_test.go
@@ -64,7 +64,7 @@ func sendTestBlobs(ch chan blob.SizedRef, list string, size uint32) {
 		return
 	}
 	for _, br := range strings.Split(list, ",") {
-		ch <- blob.SizedRef{blob.MustParse(br), size}
+		ch <- blob.SizedRef{Ref: blob.MustParse(br), Size: size}
 	}
 }
 

--- a/pkg/client/android/androidx.go
+++ b/pkg/client/android/androidx.go
@@ -211,7 +211,6 @@ func androidLookupHost(host string) string {
 		c <- host
 	}()
 	return <-c
-	return v
 }
 
 type StatsTransport struct {

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -317,7 +317,7 @@ func (c *Client) transportForConfig(tc *TransportConfig) http.RoundTripper {
 	}
 	transport = httpStats
 	if android.IsChild() {
-		transport = &android.StatsTransport{transport}
+		transport = &android.StatsTransport{Rt: transport}
 	}
 	return transport
 }

--- a/pkg/client/config.go
+++ b/pkg/client/config.go
@@ -593,5 +593,4 @@ func hasComponent(component, fullpath string) bool {
 		}
 		fullpath = fullpath[i+1:]
 	}
-	panic("unreachable")
 }

--- a/pkg/client/upload.go
+++ b/pkg/client/upload.go
@@ -76,7 +76,7 @@ type PutResult struct {
 }
 
 func (pr *PutResult) SizedBlobRef() blob.SizedRef {
-	return blob.SizedRef{pr.BlobRef, pr.Size}
+	return blob.SizedRef{Ref: pr.BlobRef, Size: pr.Size}
 }
 
 // TODO: ditch this type and use protocol.StatResponse directly?
@@ -123,7 +123,7 @@ func parseStatResponse(res *http.Response) (*statResponse, error) {
 		if !br.Valid() {
 			continue
 		}
-		s.HaveMap[br.String()] = blob.SizedRef{br, uint32(statItem.Size)}
+		s.HaveMap[br.String()] = blob.SizedRef{Ref: br, Size: uint32(statItem.Size)}
 	}
 	return s, nil
 }
@@ -167,7 +167,7 @@ func (c *Client) StatBlobs(ctx context.Context, blobs []blob.Ref, fn func(blob.S
 			panic("invalid blob")
 		}
 		if size, ok := c.haveCache.StatBlobCache(br); ok {
-			if err := fn(blob.SizedRef{br, size}); err != nil {
+			if err := fn(blob.SizedRef{Ref: br, Size: size}); err != nil {
 				return err
 			}
 		} else {

--- a/pkg/fs/rover.go
+++ b/pkg/fs/rover.go
@@ -267,7 +267,7 @@ func (n *roFileVersionsDir) populate(ctx context.Context) error {
 	}
 
 	Logger.Printf("roFileVersionsDir.populate(%q)", n.fullPath())
-	res, err := n.fs.client.GetClaims(ctx, &search.ClaimsRequest{n.permanode, "camliContent"})
+	res, err := n.fs.client.GetClaims(ctx, &search.ClaimsRequest{Permanode: n.permanode, AttrFilter: "camliContent"})
 	if err != nil {
 		return errors.New("error while getting claims")
 	}

--- a/pkg/gpgchallenge/gpg.go
+++ b/pkg/gpgchallenge/gpg.go
@@ -397,7 +397,7 @@ func genNonce() (string, error) {
 	return fmt.Sprintf("%x", buf), nil
 }
 
-func (cs Server) validateToken(token string) error {
+func (cs *Server) validateToken(token string) error {
 	// Check the token is one of ours, and not too old
 	parts := strings.Split(token, "-")
 	if len(parts) != 2 {
@@ -437,7 +437,7 @@ func (cs Server) validateToken(token string) error {
 	return nil
 }
 
-func (cs Server) validateTokenSignature(pk *packet.PublicKey, token, tokenSig string) error {
+func (cs *Server) validateTokenSignature(pk *packet.PublicKey, token, tokenSig string) error {
 	sig, err := cs.receiveSignedNonce(strings.NewReader(tokenSig))
 	if err != nil {
 		return err
@@ -465,7 +465,7 @@ func parsePubKey(r io.Reader) (*packet.PublicKey, error) {
 	return pk, nil
 }
 
-func (cs Server) receiveSignedNonce(r io.Reader) (*packet.Signature, error) {
+func (cs *Server) receiveSignedNonce(r io.Reader) (*packet.Signature, error) {
 	block, _ := armor.Decode(r)
 	if block == nil {
 		return nil, errors.New("can't parse armor")
@@ -751,7 +751,7 @@ func (cl *Client) signToken(token string) (string, error) {
 
 }
 
-func (cl Client) sendClaim(server, token string) error {
+func (cl *Client) sendClaim(server, token string) error {
 	pubkey, err := armorPubKey(cl.keyRing, cl.keyId)
 	if err != nil {
 		return err

--- a/pkg/importer/flickr/flickr.go
+++ b/pkg/importer/flickr/flickr.go
@@ -497,16 +497,18 @@ func (r *run) getTopLevelNode(path string, title string) (*importer.Object, erro
 func (r *run) flickrAPIRequest(result interface{}, method string, keyval ...string) error {
 	keyval = append([]string{"method", method, "format", "json", "nojsoncallback", "1"}, keyval...)
 	return importer.OAuthContext{
-		r.Context(),
-		r.oauthClient,
-		r.accessCreds}.PopulateJSONFromURL(result, http.MethodGet, apiURL, keyval...)
+		Ctx:    r.Context(),
+		Client: r.oauthClient,
+		Creds:  r.accessCreds,
+	}.PopulateJSONFromURL(result, http.MethodGet, apiURL, keyval...)
 }
 
 func (r *run) fetch(url string, form url.Values) (*http.Response, error) {
 	return importer.OAuthContext{
-		r.Context(),
-		r.oauthClient,
-		r.accessCreds}.Get(url, form)
+		Ctx:    r.Context(),
+		Client: r.oauthClient,
+		Creds:  r.accessCreds,
+	}.Get(url, form)
 }
 
 // TODO(mpl): same in twitter. refactor. Except for the additional perms in AuthorizationURL call.

--- a/pkg/importer/pinboard/pinboard_test.go
+++ b/pkg/importer/pinboard/pinboard_test.go
@@ -50,7 +50,10 @@ func TestIntegrationRun(t *testing.T) {
 
 	responder := httputil.FileResponder("testdata/batchresponse.json")
 	transport, err := httputil.NewRegexpFakeTransport([]*httputil.Matcher{
-		{`^https\://api\.pinboard\.in/v1/posts/all\?auth_token=gina:foo&format=json&results=10000&todt=\d\d\d\d.*`, responder},
+		{
+			URLRegex: `^https\://api\.pinboard\.in/v1/posts/all\?auth_token=gina:foo&format=json&results=10000&todt=\d\d\d\d.*`,
+			Fn:       responder,
+		},
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/importer/plaid/plaid.go
+++ b/pkg/importer/plaid/plaid.go
@@ -166,8 +166,7 @@ func (im *imp) Run(ctx *importer.RunContext) (err error) {
 	client := plaid.NewClient(clientID, secret, plaid.Tartan)
 	resp, _, err := client.ConnectGet(ctx.AccountNode().Attr(acctAttrToken), &opt)
 	if err != nil {
-		fmt.Errorf("connectGet: %s", err)
-		return
+		return fmt.Errorf("connectGet: %s", err)
 	}
 
 	var latestTrans string

--- a/pkg/importer/twitter/twitter.go
+++ b/pkg/importer/twitter/twitter.go
@@ -363,9 +363,10 @@ func (r *run) errorf(format string, args ...interface{}) {
 
 func (r *run) doAPI(result interface{}, apiPath string, keyval ...string) error {
 	return importer.OAuthContext{
-		r.Context(),
-		r.oauthClient,
-		r.accessCreds}.PopulateJSONFromURL(result, http.MethodGet, apiURL+apiPath, keyval...)
+		Ctx:    r.Context(),
+		Client: r.oauthClient,
+		Creds:  r.accessCreds,
+	}.PopulateJSONFromURL(result, http.MethodGet, apiURL+apiPath, keyval...)
 }
 
 // importTweets imports the tweets related to userID, through apiPath.
@@ -756,7 +757,7 @@ func (im *imp) ServeCallback(w http.ResponseWriter, r *http.Request, ctx *import
 		return
 	}
 
-	u, err := getUserInfo(importer.OAuthContext{ctx.Context, oauthClient, tokenCred})
+	u, err := getUserInfo(importer.OAuthContext{Ctx: ctx.Context, Client: oauthClient, Creds: tokenCred})
 	if err != nil {
 		httputil.ServeError(w, r, fmt.Errorf("Couldn't get user info: %v", err))
 		return

--- a/pkg/importer/twitter/twitter_test.go
+++ b/pkg/importer/twitter/twitter_test.go
@@ -46,7 +46,7 @@ func TestGetUserID(t *testing.T) {
 		}),
 	}))
 	defer cancel()
-	inf, err := getUserInfo(importer.OAuthContext{ctx, &oauth.Client{}, &oauth.Credentials{}})
+	inf, err := getUserInfo(importer.OAuthContext{Ctx: ctx, Client: &oauth.Client{}, Creds: &oauth.Credentials{}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -114,7 +114,7 @@ func TestIntegrationRun(t *testing.T) {
 
 	responder := httputil.FileResponder("testdata/user_timeline.json")
 	transport, err := httputil.NewRegexpFakeTransport([]*httputil.Matcher{
-		{`^https\://api\.twitter\.com/1.1/statuses/user_timeline.json\?`, responder},
+		{URLRegex: `^https\://api\.twitter\.com/1.1/statuses/user_timeline.json\?`, Fn: responder},
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/index/index_test.go
+++ b/pkg/index/index_test.go
@@ -56,7 +56,7 @@ func init() {
 	chunk2ref = chunk2.BlobRef()
 	chunk3ref = chunk3.BlobRef()
 
-	fileBlob = &test.Blob{fmt.Sprintf(`{"camliVersion": 1,
+	fileBlob = &test.Blob{Contents: fmt.Sprintf(`{"camliVersion": 1,
 "camliType": "file",
 "fileName": "stuff.txt",
 "parts": [
@@ -66,13 +66,13 @@ func init() {
 ]}`, chunk1ref, chunk2ref, chunk3ref)}
 	fileBlobRef = fileBlob.BlobRef()
 
-	staticSetBlob = &test.Blob{fmt.Sprintf(`{"camliVersion": 1,
+	staticSetBlob = &test.Blob{Contents: fmt.Sprintf(`{"camliVersion": 1,
 "camliType": "static-set",
 "members": [
   "%s"
 ]}`, fileBlobRef)}
 
-	dirBlob = &test.Blob{fmt.Sprintf(`{"camliVersion": 1,
+	dirBlob = &test.Blob{Contents: fmt.Sprintf(`{"camliVersion": 1,
 "camliType": "directory",
 "fileName": "someDir",
 "entries": "%s"

--- a/pkg/index/receive.go
+++ b/pkg/index/receive.go
@@ -156,11 +156,14 @@ func (ix *Index) indexReadyBlobs(ctx context.Context) {
 			failed[br] = true
 		}
 	}
-	ix.Lock()
-	defer ix.Unlock()
-	for br := range failed {
-		ix.readyReindex[br] = true
-	}
+	// TODO(aviau): This code is unreachable. Will fix this in a follow-up PR.
+	/*
+		ix.Lock()
+		defer ix.Unlock()
+		for br := range failed {
+			ix.readyReindex[br] = true
+		}
+	*/
 }
 
 // noteBlobIndexed checks if the recent indexing of br now allows the blobs that

--- a/pkg/jsonsign/jsonsign_test.go
+++ b/pkg/jsonsign/jsonsign_test.go
@@ -95,8 +95,8 @@ jyVNPb8AaaWVW1uZLg6Em61aKnbOG10B30m3CQ8dwBjF9hgmtcY0IZ/Y
 -----END PGP PUBLIC KEY BLOCK-----
 `
 
-var pubKeyBlob1 = &test.Blob{pubKey1} // user 1
-var pubKeyBlob2 = &test.Blob{pubKey2} // user 2
+var pubKeyBlob1 = &test.Blob{Contents: pubKey1} // user 1
+var pubKeyBlob2 = &test.Blob{Contents: pubKey2} // user 2
 
 var testFetcher = &test.Fetcher{}
 

--- a/pkg/schema/schema_test.go
+++ b/pkg/schema/schema_test.go
@@ -730,22 +730,22 @@ func TestLargeDirs(t *testing.T) {
 
 	// small directory, no splitting needed.
 	testLargeDir(t, []blob.Ref{
-		(&test.Blob{"AAAAAaaaaa"}).BlobRef(),
-		(&test.Blob{"BBBBBbbbbb"}).BlobRef(),
-		(&test.Blob{"CCCCCccccc"}).BlobRef(),
+		(&test.Blob{Contents: "AAAAAaaaaa"}).BlobRef(),
+		(&test.Blob{Contents: "BBBBBbbbbb"}).BlobRef(),
+		(&test.Blob{Contents: "CCCCCccccc"}).BlobRef(),
 	})
 
 	// large (over maxStaticSetMembers) directory. splitting, but no recursion needed.
 	var members []blob.Ref
 	for i := 0; i < maxStaticSetMembers+3; i++ {
-		members = append(members, (&test.Blob{fmt.Sprintf("%2d", i)}).BlobRef())
+		members = append(members, (&test.Blob{Contents: fmt.Sprintf("%2d", i)}).BlobRef())
 	}
 	testLargeDir(t, members)
 
 	// very large (over maxStaticSetMembers^2) directory. splitting with recursion.
 	members = nil
 	for i := 0; i < maxStaticSetMembers*maxStaticSetMembers+3; i++ {
-		members = append(members, (&test.Blob{fmt.Sprintf("%3d", i)}).BlobRef())
+		members = append(members, (&test.Blob{Contents: fmt.Sprintf("%3d", i)}).BlobRef())
 	}
 	testLargeDir(t, members)
 }

--- a/pkg/search/describe.go
+++ b/pkg/search/describe.go
@@ -32,6 +32,7 @@ import (
 
 	"go4.org/syncutil"
 	"go4.org/types"
+
 	"perkeep.org/internal/httputil"
 	"perkeep.org/pkg/blob"
 	"perkeep.org/pkg/schema"
@@ -136,6 +137,16 @@ type DescribeRequest struct {
 	flatRuleCache []*DescribeRule // flattened once, by flatRules
 
 	wg *sync.WaitGroup // for load requests
+}
+
+// Clone clones a DescribeRequest by JSON marshaling it and then unmarshaling it into a new object
+// (which is then also initialized with initDescribeRequest).
+func (dr *DescribeRequest) Clone() *DescribeRequest {
+	marshaled, _ := json.Marshal(dr)
+	res := new(DescribeRequest)
+	json.Unmarshal(marshaled, res)
+	dr.sh.initDescribeRequest(res)
+	return res
 }
 
 type blobrefAndDepth struct {

--- a/pkg/search/handler_test.go
+++ b/pkg/search/handler_test.go
@@ -102,14 +102,14 @@ func init() {
 	owner = index.NewOwner(indextest.KeyID, ownerRef.BlobRef())
 	signer = testSigner()
 	for _, v := range testBlobsContents {
-		testBlobs[v] = &test.Blob{v}
+		testBlobs[v] = &test.Blob{Contents: v}
 	}
 	perma123 := schema.NewPlannedPermanode("perma-123")
 	perma123signed, err := perma123.SignAt(ctxbg, signer, test.ClockOrigin)
 	if err != nil {
 		panic(err)
 	}
-	testBlobs["perma-123"] = &test.Blob{perma123signed}
+	testBlobs["perma-123"] = &test.Blob{Contents: perma123signed}
 	handlerTests = initTests()
 }
 
@@ -168,7 +168,7 @@ func (fi *fetcherIndex) addClaim(cl *schema.Builder) error {
 	if err != nil {
 		return err
 	}
-	return fi.addBlob(&test.Blob{signedcl})
+	return fi.addBlob(&test.Blob{Contents: signedcl})
 }
 
 func (fi *fetcherIndex) addPermanode(pnStr string, attrs ...string) error {
@@ -178,7 +178,7 @@ func (fi *fetcherIndex) addPermanode(pnStr string, attrs ...string) error {
 	if err != nil {
 		return err
 	}
-	tpn := &test.Blob{pns}
+	tpn := &test.Blob{Contents: pns}
 	if err := fi.addBlob(tpn); err != nil {
 		return err
 	}

--- a/pkg/search/websocket.go
+++ b/pkg/search/websocket.go
@@ -176,8 +176,7 @@ func (h *wsHub) doSearch(wq *watchedQuery) {
 	q := new(SearchQuery)
 	*q = *wq.q // shallow copy, since Query will mutate its internal state fields
 	if q.Describe != nil {
-		q.Describe = new(DescribeRequest)
-		*q.Describe = *wq.q.Describe
+		q.Describe = wq.q.Describe.Clone()
 	}
 
 	res, err := h.sh.Query(context.TODO(), q)

--- a/pkg/server/app/app.go
+++ b/pkg/server/app/app.go
@@ -139,8 +139,7 @@ func (a *Handler) handleMasterQuery(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	var masterQuery search.SearchQuery = *(sq)
-	des := *(masterQuery.Describe)
-	masterQuery.Describe = &des
+	masterQuery.Describe = masterQuery.Describe.Clone()
 	sr, err := a.sh.Query(r.Context(), sq)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("error running master query: %v", err), 500)
@@ -170,8 +169,7 @@ func (a *Handler) refreshDomainBlobs() error {
 		return errors.New("no master query")
 	}
 	var sq search.SearchQuery = *(a.masterQuery)
-	des := *(sq.Describe)
-	sq.Describe = &des
+	sq.Describe = sq.Describe.Clone()
 	sr, err := a.sh.Query(context.TODO(), &sq)
 	if err != nil {
 		return fmt.Errorf("error running master query: %v", err)

--- a/pkg/server/wizard.go
+++ b/pkg/server/wizard.go
@@ -271,17 +271,17 @@ func (sh *SetupHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	// can take care of updating it as something nicer which would fit better with the
 	// react UI. But in the meantime we don't link to it anymore.
 
-	if req.Method == "POST" {
-		err := req.ParseMultipartForm(10e6)
-		if err != nil {
-			httputil.ServeError(rw, req, err)
-			return
-		}
-		if len(req.Form) > 0 {
-			handleSetupChange(rw, req)
-		}
-		return
-	}
+	// if req.Method == "POST" {
+	// 	err := req.ParseMultipartForm(10e6)
+	// 	if err != nil {
+	// 		httputil.ServeError(rw, req, err)
+	// 		return
+	// 	}
+	// 	if len(req.Form) > 0 {
+	// 		handleSetupChange(rw, req)
+	// 	}
+	// 	return
+	// }
 
-	sendWizard(rw, req, false)
+	// sendWizard(rw, req, false)
 }

--- a/pkg/test/blob.go
+++ b/pkg/test/blob.go
@@ -64,7 +64,7 @@ func (tb *Blob) BlobRef() blob.Ref {
 }
 
 func (tb *Blob) SizedRef() blob.SizedRef {
-	return blob.SizedRef{tb.BlobRef(), tb.Size()}
+	return blob.SizedRef{Ref: tb.BlobRef(), Size: tb.Size()}
 }
 
 func (tb *Blob) BlobRefSlice() []blob.Ref {


### PR DESCRIPTION
This is mostly a rebase of #1288, with minor changes:
 - added CI tests
 - removed some of the changes that were not strictly necessary to make the code go-vet-clean
 - removed one of the fixes for pkg/index dead code. I prefer that we fix this in a smaller change, this one is big enough.

I'll close the original PR. All credits to @bobg for this one!