### PR TITLE
go-mastodon: rollback to 0.0.4

### DIFF
--- a/.github/workflows/tests-macos.yml
+++ b/.github/workflows/tests-macos.yml
@@ -15,7 +15,7 @@ jobs:
       with:
         go-version: ${{ matrix.go-version }}
 
-    - uses: actions/cache@v2
+    - uses: actions/cache@v2.1.3
       with:
         path: ~/go/pkg/mod
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/jonas-p/go-shp v0.1.1 // indirect
 	github.com/lib/pq v1.1.1
 	github.com/mailgun/mailgun-go v0.0.0-20171127222028-17e8bd11e87c
-	github.com/mattn/go-mastodon v0.0.5-0.20190517015615-8f6192e26b66
+	github.com/mattn/go-mastodon v0.0.4
 	github.com/mattn/go-sqlite3 v1.14.7-0.20201227235208-3cbdae750e52
 	github.com/miekg/dns v1.0.14
 	github.com/nf/cr2 v0.0.0-20140528043846-05d46fef4f2f

--- a/go.sum
+++ b/go.sum
@@ -243,8 +243,8 @@ github.com/mailgun/mailgun-go v0.0.0-20171127222028-17e8bd11e87c/go.mod h1:NWTyU
 github.com/mattn/go-colorable v0.1.1/go.mod h1:FuOcm+DKB9mbwrcAfNl7/TZVBZ6rcnceauSikq3lYCQ=
 github.com/mattn/go-isatty v0.0.5/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-isatty v0.0.7/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
-github.com/mattn/go-mastodon v0.0.5-0.20190517015615-8f6192e26b66 h1:TbnaLJhq+sFuqZ1wxdfF5Uk7A2J41iOobCCFnLI+RPE=
-github.com/mattn/go-mastodon v0.0.5-0.20190517015615-8f6192e26b66/go.mod h1:ZBkemyyYYhNAN5JJ0H/ZSW8HfPCW45rHFHyWNwSfpTA=
+github.com/mattn/go-mastodon v0.0.4 h1:+F2RbXbHkiBfx6SXMJEvEwZ0i8pI9nMnZhKkvjxq9Rs=
+github.com/mattn/go-mastodon v0.0.4/go.mod h1:ZBkemyyYYhNAN5JJ0H/ZSW8HfPCW45rHFHyWNwSfpTA=
 github.com/mattn/go-sqlite3 v1.14.7-0.20201227235208-3cbdae750e52 h1:UyFNu0Tv5cEd/VPtY73BK//owiWwcBZvsOkwdVdR3FY=
 github.com/mattn/go-sqlite3 v1.14.7-0.20201227235208-3cbdae750e52/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
 github.com/mattn/go-tty v0.0.0-20190424173100-523744f04859/go.mod h1:XPvLUNfbS4fJH25nqRHfWLMa1ONC8Amw+mIA639KxkE=


### PR DESCRIPTION
    go-mastodon: rollback to 0.0.4
    
    The author has removed the 0.0.5 tag (and commits). Revert to 0.0.4 until
    this is explained:
     - https://github.com/mattn/go-mastodon/issues/133
    
    I've also had to changer the cache action's version on macos due to
    permissions issues. I have raised the issue here:
     - https://github.com/actions/cache/issues/527


The tests are broken right now because of this. Actually they are flaky because it looks like some cache servers still remember the 0.0.5 tag.