### PR TITLE
devcam hook: fix bad script path

### DIFF
--- a/dev/devcam/hook.go
+++ b/dev/devcam/hook.go
@@ -55,7 +55,7 @@ func (c *hookCmd) installHook() error {
 		}
 	}
 	for _, hookFile := range hookFiles {
-		filename := hookDir + hookFile
+		filename := filepath.Join(hookDir, hookFile)
 		hookContent := fmt.Sprintf(hookScript, hookFile)
 		// If hook file exists, assume it is okay.
 		_, err := os.Stat(filename)


### PR DESCRIPTION
    devcam hook: fix bad script path
    
    This would create the hook at `.git/hookspre-commit` instead of creating
    it at `.git/hooks/pre-commit`.
