### PR TITLE
index: verify sigs on permanodes, not just claims

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -1419,11 +1419,11 @@ func (c *Client) signBlob(ctx context.Context, bb schema.Buildable, sigTime time
 	return bb.Builder().SignAt(ctx, signer, sigTime)
 }
 
-// uploadPublicKey uploads the public key (if one is defined), so
+// UploadPublicKey uploads the public key (if one is defined), so
 // subsequent (likely synchronous) indexing of uploaded signed blobs
 // will have access to the public key to verify it. In the normal
 // case, the stat cache prevents this from doing anything anyway.
-func (c *Client) uploadPublicKey(ctx context.Context) error {
+func (c *Client) UploadPublicKey(ctx context.Context) error {
 	sigRef := c.SignerPublicKeyBlobref()
 	if !sigRef.Valid() {
 		return nil
@@ -1453,7 +1453,7 @@ func (c *Client) UploadAndSignBlob(ctx context.Context, b schema.AnyBlob) (*PutR
 		return nil, err
 	}
 	c.checkMatchingKeys()
-	if err := c.uploadPublicKey(ctx); err != nil {
+	if err := c.UploadPublicKey(ctx); err != nil {
 		return nil, err
 	}
 	return c.uploadString(ctx, signed, false)
@@ -1483,7 +1483,7 @@ func (c *Client) UploadPlannedPermanode(ctx context.Context, key string, sigTime
 		return nil, err
 	}
 	c.checkMatchingKeys()
-	if err := c.uploadPublicKey(ctx); err != nil {
+	if err := c.UploadPublicKey(ctx); err != nil {
 		return nil, err
 	}
 	return c.uploadString(ctx, signed, true)

--- a/pkg/importer/test/helpers.go
+++ b/pkg/importer/test/helpers.go
@@ -18,6 +18,7 @@ limitations under the License.
 package test // import "perkeep.org/pkg/importer/test"
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"os"
@@ -82,6 +83,10 @@ func ImporterTest(t *testing.T, importerName string, transport http.RoundTripper
 	if err != nil {
 		t.Fatal(err)
 	}
+	if err := cl.UploadPublicKey(context.TODO()); err != nil {
+		t.Fatal(err)
+	}
+
 	signer, err := cl.Signer()
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/index/receive.go
+++ b/pkg/index/receive.go
@@ -322,6 +322,43 @@ func (ix *Index) commit(mm *mutationMap) error {
 	return nil
 }
 
+func (ix *Index) verifySignature(ctx context.Context, fetcher *missTrackFetcher, schemaBlob *schema.Blob) (*jsonsign.VerifyRequest, error) {
+	tf := &trackErrorsFetcher{f: fetcher}
+	vr := jsonsign.NewVerificationRequest(schemaBlob.JSON(), blob.NewSerialFetcher(ix.KeyFetcher, tf))
+	_, err := vr.Verify(ctx)
+
+	if err != nil {
+		// TODO(bradfitz): ask if the vr.Err.(jsonsign.Error).IsPermanent() and retry
+		// later if it's not permanent?
+		if tf.hasErrNotExist() {
+			return nil, errMissingDep
+		}
+		return nil, err
+	}
+
+	return vr, nil
+}
+
+func (ix *Index) populateMutationMapForSchema(ctx context.Context, fetcher *missTrackFetcher, schemaBlob *schema.Blob, mm *mutationMap) error {
+	switch schemaBlob.Type() {
+	case schema.TypePermanode:
+		_, err := ix.verifySignature(ctx, fetcher, schemaBlob)
+		return err
+	case schema.TypeClaim:
+		vr, err := ix.verifySignature(ctx, fetcher, schemaBlob)
+		if err != nil {
+			return err
+		}
+		return ix.populateClaim(ctx, fetcher, schemaBlob, vr, mm)
+	case schema.TypeFile:
+		return ix.populateFile(ctx, fetcher, schemaBlob, mm)
+	case schema.TypeDirectory:
+		return ix.populateDir(ctx, fetcher, schemaBlob, mm)
+	default:
+		return nil
+	}
+}
+
 // populateMutationMap populates keys & values that will be committed
 // into the returned map.
 //
@@ -334,16 +371,10 @@ func (ix *Index) populateMutationMap(ctx context.Context, fetcher *missTrackFetc
 		},
 	}
 	var err error
-	if blob, ok := sniffer.SchemaBlob(); ok {
-		switch blob.Type() {
-		case schema.TypeClaim:
-			err = ix.populateClaim(ctx, fetcher, blob, mm)
-		case schema.TypeFile:
-			err = ix.populateFile(ctx, fetcher, blob, mm)
-		case schema.TypeDirectory:
-			err = ix.populateDir(ctx, fetcher, blob, mm)
-		}
+	if schemaBlob, ok := sniffer.SchemaBlob(); ok {
+		err = ix.populateMutationMapForSchema(ctx, fetcher, schemaBlob, mm)
 	}
+
 	if err != nil && err != errMissingDep {
 		return nil, err
 	}
@@ -843,7 +874,7 @@ func (ix *Index) populateDeleteClaim(ctx context.Context, cl schema.Claim, vr *j
 	return nil
 }
 
-func (ix *Index) populateClaim(ctx context.Context, fetcher *missTrackFetcher, b *schema.Blob, mm *mutationMap) error {
+func (ix *Index) populateClaim(ctx context.Context, fetcher *missTrackFetcher, b *schema.Blob, vr *jsonsign.VerifyRequest, mm *mutationMap) error {
 	br := b.BlobRef()
 
 	claim, ok := b.AsClaim()
@@ -852,17 +883,6 @@ func (ix *Index) populateClaim(ctx context.Context, fetcher *missTrackFetcher, b
 		return nil
 	}
 
-	tf := &trackErrorsFetcher{f: fetcher}
-	vr := jsonsign.NewVerificationRequest(b.JSON(), blob.NewSerialFetcher(ix.KeyFetcher, tf))
-	_, err := vr.Verify(ctx)
-	if err != nil {
-		// TODO(bradfitz): ask if the vr.Err.(jsonsign.Error).IsPermanent() and retry
-		// later if it's not permanent? or maybe do this up a level?
-		if tf.hasErrNotExist() {
-			return errMissingDep
-		}
-		return err
-	}
 	verifiedKeyId := vr.SignerKeyId
 	mm.signerID = verifiedKeyId
 	mm.signerBlobRef = vr.CamliSigner


### PR DESCRIPTION
closes https://github.com/perkeep/perkeep/issues/1328

    index: verify sigs on permanodes, not just claims
    
    Index:
     - Handle bad signatures on permanodes just like we handled them on
       claims.
    
    Importer tests:
    - Make pkg/client's UploadPublicKey method public so that we can ensure
      that the key was uploaded before uploading permanodes in importer
      tests. This would otherwise be done automatically by methods such as
      UploadNewPermanode but the importer uses the Blobserver API, it
      uploads blobs with ReceiveBlob. ReceiveBlob does not know if blobs
      are schemas or regular blobs, so it couldn't know if it is
      appropriate to upload the key.