### PR TITLE
Speed S3 query on startup

### DIFF
--- a/pkg/blobserver/s3/enumerate.go
+++ b/pkg/blobserver/s3/enumerate.go
@@ -48,11 +48,16 @@ func (sto *s3Storage) EnumerateBlobs(ctx context.Context, dest chan<- blob.Sized
 
 	keysGotten := 0
 
-	err := sto.client.ListObjectsV2PagesWithContext(ctx, &s3.ListObjectsV2Input{
+	lo := &s3.ListObjectsV2Input{
 		Bucket:     &sto.bucket,
 		StartAfter: aws.String(sto.dirPrefix + after),
 		MaxKeys:    maxKeys,
-	}, func(page *s3.ListObjectsV2Output, lastPage bool) bool {
+	}
+	if sto.dirPrefix != "" {
+		lo.Prefix = &sto.dirPrefix
+	}
+
+	err := sto.client.ListObjectsV2PagesWithContext(ctx, lo, func(page *s3.ListObjectsV2Output, lastPage bool) bool {
 		for _, obj := range page.Contents {
 			dir, file := path.Split(*obj.Key)
 			if dir != sto.dirPrefix {


### PR DESCRIPTION
Currently I have both a local filesystem blobstore as well as s3 as a backup. When the service starts up it is querying to see if files exist in s3. However I have no files that start with 'packed' and iterating all 400k sha224 blobs takes FOREVER.

S3 does not have 'folders' only prefixes and so we can query all files from the packed "directory" by adding the s3Storage.dirPrefix to our query.

With this change my server now starts up instantly.
