### PR TITLE
web-ui/importer: use relative links for importers and accounts

### DIFF
--- a/pkg/importer/html.go
+++ b/pkg/importer/html.go
@@ -107,7 +107,7 @@ var tmpl = template.Must(template.New("root").Funcs(map[string]interface{}{
          {{if .TODOIssue}}
              <li><b>{{.Title}}</b>: TODO: <a href="https://perkeep.org/issue/{{.TODOIssue}}">Issue {{.TODOIssue}}</a></li>
          {{else}}
-             <li><b><a href="{{$base}}{{.Name}}">{{.Title}}</a></b>{{if .Description}}: {{.Description}}{{end}}</li>
+             <li><b><a href="{{.Name}}">{{.Title}}</a></b>{{if .Description}}: {{.Description}}{{end}}</li>
          {{end}}
       {{end}}
    </ul>

--- a/pkg/importer/importer.go
+++ b/pkg/importer/importer.go
@@ -1163,7 +1163,7 @@ func (ia *importerAcct) AccountObject() *Object { return ia.acct }
 func (ia *importerAcct) RootObject() *Object    { return ia.root }
 
 func (ia *importerAcct) AccountURL() string {
-	return ia.im.URL() + "/" + ia.acct.PermanodeRef().String()
+	return "/" + ia.acct.PermanodeRef().String()
 }
 
 func (ia *importerAcct) AccountLinkText() string {


### PR DESCRIPTION
In some network configurations it's annoying that the links in the importer
web ui point to the configured base URL. If you use VPN like tailcale you
might not have the same URL (like home network IP)to access the server.

This changes the links in the web UI to relatives URLs. Since this method
is only used in the web UI it should be pretty safe.