### PR TITLE
Add a "static site" handler to serve resources from a camliRoot

### DIFF
--- a/app/staticapp/main.go
+++ b/app/staticapp/main.go
@@ -1,0 +1,297 @@
+/*
+Copyright 2021 The Perkeep Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// The Static App application serves static web resources stored in a Perkeep camliRoot directory.
+package main // import "perkeep.org/app/staticapp"
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+	"perkeep.org/pkg/app"
+	"perkeep.org/pkg/blob"
+	"perkeep.org/pkg/blobserver/localdisk"
+	"perkeep.org/pkg/buildinfo"
+	"perkeep.org/pkg/cacher"
+	"perkeep.org/pkg/schema"
+	"perkeep.org/pkg/search"
+	"perkeep.org/pkg/webserver"
+	"runtime"
+	"strings"
+	"time"
+)
+
+var (
+	flagVersion = flag.Bool("version", false, "show version")
+)
+
+type config struct {
+	StaticRoot string `json:"staticRoot"`
+	CacheRoot  string `json:"cacheRoot,omitempty"`  // Root path for the caching blobserver. No caching if empty.
+	SearchRoot string `json:"searchRoot,omitempty"` // Root path for initializing app search with a master query. No search if empty.
+}
+
+func appConfig() *config {
+	configURL := os.Getenv("CAMLI_APP_CONFIG_URL")
+	if configURL == "" {
+		log.Fatalf("Static App application needs a CAMLI_APP_CONFIG_URL env var")
+	}
+	cl, err := app.Client()
+	if err != nil {
+		log.Fatalf("could not get a client to fetch extra config: %v", err)
+	}
+	conf := &config{}
+	if err := cl.GetJSON(context.TODO(), configURL, conf); err != nil {
+		log.Fatalf("could not get app config at %v: %v", configURL, err)
+	}
+	return conf
+}
+
+type client interface {
+	search.QueryDescriber
+	GetJSON(ctx context.Context, url string, data interface{}) error
+	blob.Fetcher
+}
+
+type staticAppHandler struct {
+	rootDirRef string
+	cl         client
+	fetcher    blob.Fetcher
+}
+
+func (sa *staticAppHandler) treeConstraint(filePath string) *search.FileConstraint {
+	filePath = strings.TrimPrefix(filePath, "/")
+	tree := strings.Split(filePath, "/")
+
+	fileName, tree := tree[len(tree)-1], tree[:len(tree)-1]
+	fc := &search.FileConstraint{FileName: &search.StringConstraint{Equals: fileName}}
+
+	if len(tree) != 0 {
+		dirName, parts := tree[len(tree)-1], tree[:len(tree)-1]
+		fc.ParentDir = &search.DirConstraint{FileName: &search.StringConstraint{Equals: dirName}}
+
+		var pn string
+		var ancestor = fc.ParentDir
+		last := len(parts) - 1
+		for pi := range parts {
+			pn = parts[last-pi]
+			ancestor.ParentDir = &search.DirConstraint{FileName: &search.StringConstraint{Equals: pn}}
+			ancestor = ancestor.ParentDir
+		}
+		ancestor.ParentDir = &search.DirConstraint{BlobRefPrefix: sa.rootDirRef}
+	} else {
+		fc.ParentDir = &search.DirConstraint{BlobRefPrefix: sa.rootDirRef}
+	}
+
+	return fc
+}
+
+func (sa *staticAppHandler) initStaticRoot(rootName string) (string, error) {
+	result, err := sa.cl.Query(context.TODO(), &search.SearchQuery{
+		Limit: 1,
+		Constraint: &search.Constraint{
+			Logical: &search.LogicalConstraint{
+				A: &search.Constraint{
+					Permanode: &search.PermanodeConstraint{
+						Attr:       "camliRoot",
+						Value:      rootName,
+						SkipHidden: true,
+					},
+				},
+				B: &search.Constraint{
+					Permanode: &search.PermanodeConstraint{
+						Attr: "camliContent",
+						ValueInSet: &search.Constraint{
+							CamliType: "directory",
+						},
+						SkipHidden: true,
+					},
+				},
+				Op: "and",
+			},
+		},
+		Describe: &search.DescribeRequest{},
+	})
+	if err != nil {
+		return "", err
+	}
+	if len(result.Blobs) == 0 || !result.Blobs[0].Blob.Valid() {
+		return "", os.ErrNotExist
+	}
+	found := result.Blobs[0].Blob.String()
+	root := result.Describe.Meta[found]
+	return root.Permanode.Attr.Get("camliContent"), nil
+}
+
+func (sa *staticAppHandler) getFile(filePath string) (*search.DescribedBlob, error) {
+	fileTree := sa.treeConstraint(filePath)
+	result, err := sa.cl.Query(context.TODO(), &search.SearchQuery{
+		Limit:      1,
+		Constraint: &search.Constraint{File: fileTree},
+		Describe:   &search.DescribeRequest{},
+	})
+	if err != nil {
+		return &search.DescribedBlob{}, err
+	}
+	if len(result.Blobs) == 0 || !result.Blobs[0].Blob.Valid() {
+		return &search.DescribedBlob{}, os.ErrNotExist
+	}
+	found := result.Blobs[0].Blob.String()
+	return result.Describe.Meta[found], nil
+}
+
+func (sa *staticAppHandler) setMasterQuery(searchRoot string) error {
+	masterQueryURL := os.Getenv("CAMLI_APP_MASTERQUERY_URL")
+	if masterQueryURL == "" {
+		return fmt.Errorf("missing CAMLI_APP_MASTERQUERY_URL env var")
+	}
+	query := &search.SearchQuery{
+		Sort:  search.CreatedDesc,
+		Limit: -1,
+		Constraint: &search.Constraint{
+			Permanode: &search.PermanodeConstraint{
+				Relation: &search.RelationConstraint{
+					Relation: "parent",
+					Any: &search.Constraint{
+						Permanode: &search.PermanodeConstraint{
+							Attr:  "camliRoot",
+							Value: searchRoot,
+						},
+					},
+				},
+			},
+		},
+		Describe: &search.DescribeRequest{
+			Depth: 1,
+			Rules: []*search.DescribeRule{
+				{Attrs: []string{"camliContent", "camliContentImage", "camliMember", "camliPath:*"}},
+			},
+		},
+	}
+	data, err := json.Marshal(query)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequest("POST", masterQueryURL, bytes.NewReader(data))
+	if err != nil {
+		return err
+	}
+	am, err := app.Auth()
+	if err != nil {
+		return err
+	}
+	am.AddAuthHeader(req)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	if string(body) != "OK" {
+		return fmt.Errorf("error setting master query on app handler: %v", string(body))
+	}
+	return nil
+}
+
+func (sa *staticAppHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	reqPath := app.PathPrefix(r)
+	filePath := strings.TrimPrefix(r.URL.Path, reqPath)
+	if filePath == "" {
+		filePath = "index.html"
+	}
+
+	file, err := sa.getFile(filePath)
+	if err != nil {
+		log.Printf("file blob not found with path %s - %s", filePath, err)
+		http.NotFound(w, r)
+	} else {
+		fr, err := schema.NewFileReader(r.Context(), sa.fetcher, file.BlobRef)
+		if err != nil {
+			log.Printf("%s", err)
+			http.Error(w, fmt.Sprintf("server error while fetching %s at %s", filePath, file.BlobRef), 500)
+		} else {
+			http.ServeContent(w, r, file.File.FileName, time.Now(), fr)
+		}
+	}
+}
+
+func newStaticAppHandler(conf *config) *staticAppHandler {
+	cl, err := app.Client()
+	if err != nil {
+		log.Fatalf("could not get a client for the staticapp app handler %v", err)
+	}
+	var fetcher blob.Fetcher
+	if conf.CacheRoot != "" {
+		cache, err := localdisk.New(conf.CacheRoot)
+		if err != nil {
+			log.Fatalf("Could not create localdisk fetcher: %v", err)
+		}
+		fetcher = cacher.NewCachingFetcher(cache, cl)
+	} else {
+		fetcher = cl
+	}
+	sa := &staticAppHandler{
+		cl:      cl,
+		fetcher: fetcher,
+	}
+	staticRoot, err := sa.initStaticRoot(conf.StaticRoot)
+	if err != nil {
+		log.Fatalf("failed to initialize static content directory: %v", err)
+	}
+	sa.rootDirRef = staticRoot
+	if conf.SearchRoot != "" {
+		err = sa.setMasterQuery(conf.SearchRoot)
+		if err != nil {
+			log.Fatalf("failed to set master query %v", err)
+		}
+	}
+	return sa
+}
+
+func main() {
+	flag.Parse()
+
+	if *flagVersion {
+		fmt.Fprintf(os.Stderr, "staticapp version: %s\nGo version: %s (%s/%s)\n",
+			buildinfo.Summary(), runtime.Version(), runtime.GOOS, runtime.GOARCH)
+		return
+	}
+
+	log.Printf("Starting staticapp version %s; Go %s (%s/%s)", buildinfo.Summary(), runtime.Version(),
+		runtime.GOOS, runtime.GOARCH)
+	listenAddr, err := app.ListenAddress()
+	if err != nil {
+		log.Fatalf("Listen address: %v", err)
+	}
+	conf := appConfig()
+	sa := newStaticAppHandler(conf)
+	ws := webserver.New()
+	ws.Handle("/", sa)
+	if err := ws.Listen(listenAddr); err != nil {
+		log.Fatalf("Listen: %v", err)
+	}
+
+	ws.Serve()
+}

--- a/app/staticapp/staticapp_test.go
+++ b/app/staticapp/staticapp_test.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"perkeep.org/internal/testhooks"
+	"perkeep.org/pkg/blob"
+	camliClient "perkeep.org/pkg/client"
+	"perkeep.org/pkg/index"
+	"perkeep.org/pkg/index/indextest"
+	"perkeep.org/pkg/search"
+	"testing"
+	"time"
+)
+
+func init() {
+	testhooks.SetUseSHA1(true)
+}
+
+type fakeClient struct {
+	*camliClient.Client
+	sh *search.Handler
+}
+
+func (fc *fakeClient) Query(ctx context.Context, req *search.SearchQuery) (*search.SearchResult, error) {
+	return fc.sh.Query(ctx, req)
+}
+
+func TestStaticApp_TreeConstraint(t *testing.T) {
+	h := &staticAppHandler{
+		rootDirRef: "rootDirRef",
+		cl:         &camliClient.Client{},
+	}
+	result := h.treeConstraint("path/to/file/index.html")
+	resultJSON, err := json.Marshal(result)
+	if err != nil {
+		log.Fatalf(err.Error())
+	}
+	expected := []byte(`{
+	  "fileName": {
+		"equals": "index.html"
+	  },
+	  "wholeRef": null,
+	  "parentDir": {
+		"fileName": {
+		  "equals": "file"
+		},
+		"parentDir": {
+		  "fileName": {
+			"equals": "to"
+		  },
+		  "parentDir": {
+			"fileName": {
+			  "equals": "path"
+			},
+			"parentDir": {
+			  "blobRefPrefix": "rootDirRef"
+			}
+		  }
+		}
+	  }
+	}`)
+	buffer := new(bytes.Buffer)
+	if err := json.Compact(buffer, expected); err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Compare(resultJSON, buffer.Bytes()) != 0 {
+		t.Errorf("Unexpected file constraint query, got %s", string(resultJSON))
+	}
+}
+
+type staticAppReqTest struct {
+	path   string // input
+	status int    // expected
+}
+
+var staticAppReqTests []staticAppReqTest
+
+func TestStaticApp_ServeHTTP(t *testing.T) {
+	idx := index.NewMemoryIndex()
+	idxd := indextest.NewIndexDeps(idx)
+	ownerRef := indextest.PubKey
+	owner := index.NewOwner(indextest.KeyID, ownerRef.BlobRef())
+	sh := search.NewHandler(idxd.Index, owner)
+
+	staticRoot := idxd.NewPlannedPermanode("staticRoot")
+	indexHTML, _ := idxd.UploadFile("index.html", "<!DOCTYPE html><html><head></head><body></body></html>", time.Time{})
+	staticDir := idxd.UploadDir("test-app", []blob.Ref{indexHTML}, time.Time{})
+	idxd.SetAttribute(staticRoot, "camliRoot", "test-app")
+	idxd.SetAttribute(staticRoot, "camliContent", staticDir.String())
+
+	corpus, err := idxd.Index.KeepInMemory()
+	if err != nil {
+		t.Fatalf("error slurping index to memory: %v", err)
+	}
+	sh.SetCorpus(corpus)
+
+	cl, err := camliClient.New(camliClient.OptionServer("http://perkeep-test.com"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	fcl := &fakeClient{cl, sh}
+	sa := &staticAppHandler{
+		rootDirRef: staticDir.String(),
+		cl:         fcl,
+		fetcher:    idxd.BlobSource,
+	}
+
+	staticAppReqTests = []staticAppReqTest{
+		{
+			path:   "/index.html",
+			status: http.StatusOK,
+		},
+		{
+			path:   "/does_not_exist.html",
+			status: http.StatusNotFound,
+		},
+	}
+
+	for i, rt := range staticAppReqTests {
+		w := httptest.NewRecorder()
+		r, _ := http.NewRequest("GET", fmt.Sprintf("http://test.com%s", rt.path), nil)
+		sa.ServeHTTP(w, r)
+
+		if w.Code != rt.status {
+			t.Errorf("test #%d, got status %q, want %q", i, rt.status, w.Code)
+		}
+	}
+}

--- a/config/dev-server-config.json
+++ b/config/dev-server-config.json
@@ -33,6 +33,19 @@
 			}
 		},
 
+		"/static-app/": {
+			"handler": "app",
+			"enabled": ["_env", "${CAMLI_STATICAPP_ENABLED}"],
+			"handlerArgs": {
+				"prefix": "/static-app/",
+				"serverListen": "localhost:3179",
+				"program": "staticapp",
+				"appConfig": {
+					"staticRoot": "Static App Source"
+				}
+			}
+		},
+
 		"/scancab/": {
 			"handler": "app",
 			"enabled": ["_env", "${CAMLI_SCANCAB_ENABLED}"],

--- a/dev/devcam/server.go
+++ b/dev/devcam/server.go
@@ -70,6 +70,7 @@ type serverCmd struct {
 	publish     bool // whether to build and start the publisher app(s)
 	scancab     bool // whether to build and start the scancab app(s)
 	hello       bool // whether to build and start the hello demo app
+	staticapp   bool // whether to build and start the staticapp demo app
 
 	openBrowser      bool
 	flickrAPIKey     string
@@ -103,6 +104,7 @@ func init() {
 		flags.BoolVar(&cmd.publish, "publish", true, "Enable publisher app(s)")
 		flags.BoolVar(&cmd.scancab, "scancab", false, "Enable scancab app(s)")
 		flags.BoolVar(&cmd.hello, "hello", false, "Enable hello (demo) app")
+		flags.BoolVar(&cmd.staticapp, "staticapp", false, "Enable static app (demo) app")
 		flags.BoolVar(&cmd.mini, "mini", false, "Enable minimal mode, where all optional features are disabled. (Currently just publishing)")
 
 		flags.BoolVar(&cmd.mongo, "mongo", false, "Use mongodb as the index storage. Excludes -mysql, -postgres, -sqlite, -memory, -kvfile.")
@@ -160,6 +162,7 @@ func (c *serverCmd) checkFlags(args []string) error {
 		c.publish = false
 		c.scancab = false
 		c.hello = false
+		c.staticapp = false
 	}
 	if c.things && !c.wipe {
 		return cmdmain.UsageError("--makethings requires --wipe.")
@@ -236,6 +239,7 @@ func (c *serverCmd) setEnvVars() error {
 	setenv("CAMLI_PUBLISH_ENABLED", strconv.FormatBool(c.publish))
 	setenv("CAMLI_SCANCAB_ENABLED", strconv.FormatBool(c.scancab))
 	setenv("CAMLI_HELLO_ENABLED", strconv.FormatBool(c.hello))
+	setenv("CAMLI_STATICAPP_ENABLED", strconv.FormatBool(c.staticapp))
 	setenv("CAMLI_SHA1_ENABLED", strconv.FormatBool(c.sha1))
 	switch {
 	case c.memory:
@@ -518,6 +522,9 @@ func (c *serverCmd) RunCommand(args []string) error {
 		}
 		if c.hello {
 			targets = append(targets, "app/hello")
+		}
+		if c.staticapp {
+			targets = append(targets, "app/staticapp")
 		}
 		if c.publish {
 			targets = append(targets, "app/publisher")


### PR DESCRIPTION
This PR adds a static site app handler to enable serving static web resources, like a single page app, from a configured camliRoot node.

Once you configure the handler, you can "install" the app by uploading the files to a camliRoot.

Upload files with: `pk-put file --permanode --title='Static App Source' ./test-app-source`

You can also configure a search root for the app handler to enable searching via the app route:
`pk-put permanode --title='Test App Search Root'`

```
"/static-app/": {
	"handler": "app",
	"enabled": ["_env", "${CAMLI_STATICAPP_ENABLED}"],
	"handlerArgs": {
		"prefix": "/static-app/",
		"serverListen": "localhost:3179",
		"program": "staticapp",
		"appConfig": {
			"staticRoot": "Static App Source",
			"searchRoot": "Test App Search Root"
		}
	}
}
```

Then the app endpoint will support searching with queries limited to nodes in the specified search root:
```bash
$ devcam server -staticapp
$ curl -X POST http://localhost:3179/test-app/search -d' { "expression" : "is:image", "describe": {} } '
```