### PR TITLE
all: use `T.TempDir` to create temporary directory

### DIFF
--- a/cmd/pk-put/camput_test.go
+++ b/cmd/pk-put/camput_test.go
@@ -120,12 +120,7 @@ func TestUploadingChangingDirectory(t *testing.T) {
 }
 
 func testWithTempDir(t *testing.T, fn func(tempDir string)) {
-	tempDir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Errorf("error creating temp dir: %v", err)
-		return
-	}
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 
 	confDir := filepath.Join(tempDir, "conf")
 	mustMkdir(t, confDir, 0700)

--- a/internal/osutil/paths_test.go
+++ b/internal/osutil/paths_test.go
@@ -93,18 +93,9 @@ func TestOpenCamliIncludeCWD(t *testing.T) {
 	checkOpen(t, path)
 }
 
-func tempDir(t *testing.T) (path string, cleanup func()) {
-	dir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatalf("making tempdir: %v", err)
-	}
-	return dir, func() { os.RemoveAll(dir) }
-}
-
 // Test for when a file exists in CAMLI_CONFIG_DIR
 func TestOpenCamliIncludeDir(t *testing.T) {
-	td, clean := tempDir(t)
-	defer clean()
+	td := t.TempDir()
 
 	const name string = "TestOpenCamliIncludeDir.config"
 	if e := createTestInclude(filepath.Join(td, name)); e != nil {
@@ -119,8 +110,7 @@ func TestOpenCamliIncludeDir(t *testing.T) {
 
 // Test for when a file exits in CAMLI_INCLUDE_PATH
 func TestOpenCamliIncludePath(t *testing.T) {
-	td, clean := tempDir(t)
-	defer clean()
+	td := t.TempDir()
 
 	const name string = "TestOpenCamliIncludePath.config"
 	if e := createTestInclude(filepath.Join(td, name)); e != nil {
@@ -152,11 +142,7 @@ func TestCamPkConfigMigration(t *testing.T) {
 	}()
 	log.SetOutput(ioutil.Discard)
 
-	td, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(td)
+	td := t.TempDir()
 
 	configDirNamedTestHook = func(name string) string {
 		return filepath.Join(td, name)

--- a/pkg/blobserver/diskpacked/stream_test.go
+++ b/pkg/blobserver/diskpacked/stream_test.go
@@ -23,7 +23,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -107,17 +106,14 @@ func writePack(t *testing.T, dir string, i int, p pack) {
 
 func newTestStorage(t *testing.T, packs ...pack) (s *storage, clean func()) {
 	restoreLogging := test.TLog(t)
-	dir, err := ioutil.TempDir("", "diskpacked-test")
-	if err != nil {
-		t.Fatal(err)
-	}
+	dir := t.TempDir()
 
 	for i, p := range packs {
 		writePack(t, dir, i, p)
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
-	err = Reindex(ctx, dir, true, nil)
+	err := Reindex(ctx, dir, true, nil)
 	cancel()
 	if err != nil {
 		t.Fatalf("Reindexing after writing pack files: %v", err)
@@ -129,7 +125,6 @@ func newTestStorage(t *testing.T, packs ...pack) (s *storage, clean func()) {
 
 	clean = func() {
 		s.Close()
-		os.RemoveAll(dir)
 		restoreLogging()
 	}
 	return s, clean

--- a/pkg/index/kvfile_test.go
+++ b/pkg/index/kvfile_test.go
@@ -17,8 +17,6 @@ limitations under the License.
 package index_test
 
 import (
-	"io/ioutil"
-	"os"
 	"path/filepath"
 	"sync"
 	"testing"
@@ -32,18 +30,13 @@ import (
 )
 
 func newKvfileSorted(t *testing.T) (kv sorted.KeyValue, cleanup func()) {
-	td, err := ioutil.TempDir("", "kvfile-test")
+	td := t.TempDir()
+	kv, err := kvfile.NewStorage(filepath.Join(td, "kvfile"))
 	if err != nil {
-		t.Fatal(err)
-	}
-	kv, err = kvfile.NewStorage(filepath.Join(td, "kvfile"))
-	if err != nil {
-		os.RemoveAll(td)
 		t.Fatal(err)
 	}
 	return kv, func() {
 		kv.Close()
-		os.RemoveAll(td)
 	}
 }
 

--- a/pkg/index/leveldb_test.go
+++ b/pkg/index/leveldb_test.go
@@ -17,8 +17,6 @@ limitations under the License.
 package index_test
 
 import (
-	"io/ioutil"
-	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -30,18 +28,13 @@ import (
 )
 
 func newLevelDBSorted(t *testing.T) (kv sorted.KeyValue, cleanup func()) {
-	td, err := ioutil.TempDir("", "camli-index-leveldb")
+	td := t.TempDir()
+	kv, err := leveldb.NewStorage(filepath.Join(td, "leveldb"))
 	if err != nil {
-		t.Fatal(err)
-	}
-	kv, err = leveldb.NewStorage(filepath.Join(td, "leveldb"))
-	if err != nil {
-		os.RemoveAll(td)
 		t.Fatal(err)
 	}
 	return kv, func() {
 		kv.Close()
-		os.RemoveAll(td)
 	}
 }
 

--- a/pkg/schema/schema_test.go
+++ b/pkg/schema/schema_test.go
@@ -72,11 +72,7 @@ func TestRegularFile(t *testing.T) {
 }
 
 func TestSymlink(t *testing.T) {
-	td, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(td)
+	td := t.TempDir()
 
 	symFile := filepath.Join(td, "test-symlink")
 	if err := os.Symlink("test-target", symFile); err != nil {
@@ -571,11 +567,7 @@ func TestStaticFileAndStaticSymlink(t *testing.T) {
 		t.Fatalf("StaticFile.AsStaticSymlink(): Unexpected return value: true")
 	}
 
-	dir, err := ioutil.TempDir("", "schema-test-")
-	if err != nil {
-		t.Fatalf("ioutil.TempDir(): %v", err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	target := "bar"
 	src := filepath.Join(dir, "foo")
@@ -617,14 +609,10 @@ func TestStaticFileAndStaticSymlink(t *testing.T) {
 }
 
 func TestStaticFIFO(t *testing.T) {
-	tdir, err := ioutil.TempDir("", "schema-test-")
-	if err != nil {
-		t.Fatalf("ioutil.TempDir(): %v", err)
-	}
-	defer os.RemoveAll(tdir)
+	tdir := t.TempDir()
 
 	fifoPath := filepath.Join(tdir, "fifo")
-	err = osutil.Mkfifo(fifoPath, 0660)
+	err := osutil.Mkfifo(fifoPath, 0660)
 	if err == osutil.ErrNotSupported {
 		t.SkipNow()
 	}
@@ -654,14 +642,10 @@ func TestStaticFIFO(t *testing.T) {
 }
 
 func TestStaticSocket(t *testing.T) {
-	tdir, err := ioutil.TempDir("", "schema-test-")
-	if err != nil {
-		t.Fatalf("ioutil.TempDir(): %v", err)
-	}
-	defer os.RemoveAll(tdir)
+	tdir := t.TempDir()
 
 	sockPath := filepath.Join(tdir, "socket")
-	err = osutil.Mksocket(sockPath)
+	err := osutil.Mksocket(sockPath)
 	if err == osutil.ErrNotSupported {
 		t.SkipNow()
 	}

--- a/pkg/test/integration/camget_test.go
+++ b/pkg/test/integration/camget_test.go
@@ -35,11 +35,7 @@ import (
 func TestCamgetSymlink(t *testing.T) {
 	w := test.GetWorld(t)
 
-	srcDir, err := ioutil.TempDir("", "pk-get-test-")
-	if err != nil {
-		t.Fatalf("ioutil.TempDir(): %v", err)
-	}
-	defer os.RemoveAll(srcDir)
+	srcDir := t.TempDir()
 
 	targetBase := "a"
 	target := filepath.Join(srcDir, targetBase)
@@ -70,11 +66,7 @@ func TestCamgetSymlink(t *testing.T) {
 	// TODO(mpl): rm call and delete pkg.
 	asserts.ExpectBool(t, true, out != "", "pk-put")
 	br := strings.Split(out, "\n")[0]
-	dstDir, err := ioutil.TempDir("", "pk-get-test-")
-	if err != nil {
-		t.Fatalf("ioutil.TempDir(): %v", err)
-	}
-	defer os.RemoveAll(dstDir)
+	dstDir := t.TempDir()
 
 	// Now restore the symlink
 	_ = test.MustRunCmd(t, w.Cmd("pk-get", "-o", dstDir, br))
@@ -104,8 +96,7 @@ func TestCamgetFIFO(t *testing.T) {
 		t.SkipNow()
 	}
 
-	fifo, cleanup := mkTmpFIFO(t)
-	defer cleanup()
+	fifo := mkTmpFIFO(t)
 
 	// Upload the fifo
 	w := test.GetWorld(t)
@@ -113,11 +104,7 @@ func TestCamgetFIFO(t *testing.T) {
 	br := strings.Split(out, "\n")[0]
 
 	// Try and get it back
-	tdir, err := ioutil.TempDir("", "fifo-test-")
-	if err != nil {
-		t.Fatalf("ioutil.TempDir(): %v", err)
-	}
-	defer os.RemoveAll(tdir)
+	tdir := t.TempDir()
 	test.MustRunCmd(t, w.Cmd("pk-get", "-o", tdir, br))
 
 	// Ensure it is actually a fifo
@@ -137,8 +124,7 @@ func TestCamgetSocket(t *testing.T) {
 		t.SkipNow()
 	}
 
-	socket, cleanup := mkTmpSocket(t)
-	defer cleanup()
+	socket := mkTmpSocket(t)
 
 	// Upload the socket
 	w := test.GetWorld(t)
@@ -146,11 +132,7 @@ func TestCamgetSocket(t *testing.T) {
 	br := strings.Split(out, "\n")[0]
 
 	// Try and get it back
-	tdir, err := ioutil.TempDir("", "socket-test-")
-	if err != nil {
-		t.Fatalf("ioutil.TempDir(): %v", err)
-	}
-	defer os.RemoveAll(tdir)
+	tdir := t.TempDir()
 	test.MustRunCmd(t, w.Cmd("pk-get", "-o", tdir, br))
 
 	// Ensure it is actually a socket
@@ -169,11 +151,7 @@ func TestCamgetSocket(t *testing.T) {
 // 2) if the file already exists, and has the same size as the one held by the server,
 // stop early and do not even fetch it from the server.
 func TestCamgetFile(t *testing.T) {
-	dirName, err := ioutil.TempDir("", "camli-TestCamgetFile")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dirName)
+	dirName := t.TempDir()
 	f, err := os.Create(filepath.Join(dirName, "test.txt"))
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/test/integration/camlistore_test.go
+++ b/pkg/test/integration/camlistore_test.go
@@ -164,14 +164,6 @@ func TestNoTestingLinking(t *testing.T) {
 	}
 }
 
-func mustTempDir(t *testing.T) (name string, cleanup func()) {
-	dir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	return dir, func() { os.RemoveAll(dir) }
-}
-
 func mustWriteFile(t *testing.T, path, contents string) {
 	err := ioutil.WriteFile(path, []byte(contents), 0644)
 	if err != nil {
@@ -188,8 +180,7 @@ func TestAndroidCamputFile(t *testing.T) {
 	//   CAMLI_TRUSTED_CERT (not needed)
 	//   CAMLI_CACHE_DIR
 	//   CAMPUT_ANDROID_OUTPUT=1
-	cacheDir, clean := mustTempDir(t)
-	defer clean()
+	cacheDir := t.TempDir()
 	env := append(os.Environ(),
 		"CAMPUT_ANDROID_OUTPUT=1",
 		"CAMLI_CACHE_DIR="+cacheDir,
@@ -217,8 +208,7 @@ func TestAndroidCamputFile(t *testing.T) {
 	}
 	defer cmd.Process.Kill()
 
-	srcDir, clean := mustTempDir(t)
-	defer clean()
+	srcDir := t.TempDir()
 
 	file1 := filepath.Join(srcDir, "file1.txt")
 	mustWriteFile(t, file1, "contents 1")

--- a/pkg/test/integration/camput_test.go
+++ b/pkg/test/integration/camput_test.go
@@ -18,7 +18,6 @@ package integration
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -30,19 +29,12 @@ import (
 	"perkeep.org/pkg/test"
 )
 
-// mkTmpFIFO makes a fifo in a temporary directory and returns the
-// path it and a function to clean-up when done.
-func mkTmpFIFO(t *testing.T) (path string, cleanup func()) {
-	tdir, err := ioutil.TempDir("", "fifo-test-")
-	if err != nil {
-		t.Fatalf("iouti.TempDir(): %v", err)
-	}
-	cleanup = func() {
-		os.RemoveAll(tdir)
-	}
+// mkTmpFIFO makes a fifo in a temporary directory and returns the path to it.
+func mkTmpFIFO(t *testing.T) (path string) {
+	tdir := t.TempDir()
 
 	path = filepath.Join(tdir, "fifo")
-	err = osutil.Mkfifo(path, 0660)
+	err := osutil.Mkfifo(path, 0660)
 	if err != nil {
 		t.Fatalf("osutil.mkfifo(): %v", err)
 	}
@@ -56,8 +48,7 @@ func TestCamputFIFO(t *testing.T) {
 		t.SkipNow()
 	}
 
-	fifo, cleanup := mkTmpFIFO(t)
-	defer cleanup()
+	fifo := mkTmpFIFO(t)
 
 	// Can we successfully upload a fifo?
 	w := test.GetWorld(t)
@@ -68,19 +59,13 @@ func TestCamputFIFO(t *testing.T) {
 	t.Logf("Retrieved stored fifo schema: %s", out)
 }
 
-// mkTmpSocket makes a socket in a temporary directory and returns the
-// path to it and a function to clean-up when done.
-func mkTmpSocket(t *testing.T) (path string, cleanup func()) {
-	tdir, err := ioutil.TempDir("", "socket-test-")
-	if err != nil {
-		t.Fatalf("iouti.TempDir(): %v", err)
-	}
-	cleanup = func() {
-		os.RemoveAll(tdir)
-	}
+// mkTmpSocket makes a socket in a temporary directory and returns the path to
+// it.
+func mkTmpSocket(t *testing.T) (path string) {
+	tdir := t.TempDir()
 
 	path = filepath.Join(tdir, "socket")
-	err = osutil.Mksocket(path)
+	err := osutil.Mksocket(path)
 	if err != nil {
 		t.Fatalf("osutil.Mksocket(): %v", err)
 	}
@@ -94,8 +79,7 @@ func TestCamputSocket(t *testing.T) {
 		t.SkipNow()
 	}
 
-	socket, cleanup := mkTmpSocket(t)
-	defer cleanup()
+	socket := mkTmpSocket(t)
 
 	// Can we successfully upload a socket?
 	w := test.GetWorld(t)

--- a/pkg/test/integration/non-utf8_test.go
+++ b/pkg/test/integration/non-utf8_test.go
@@ -19,7 +19,6 @@ package integration
 import (
 	"bytes"
 	"encoding/hex"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -32,25 +31,11 @@ import (
 
 var nonUTF8 = "416c697ae965202d204d6f69204c6f6c6974612e6d7033" // hex-encoding
 
-func tempDir(t *testing.T) (path string, cleanup func()) {
-	path, err := ioutil.TempDir("", "camtest-")
-	if err != nil {
-		t.Fatalf("ioutil.TempDir(): %v", err)
-	}
-
-	cleanup = func() {
-		os.RemoveAll(path)
-	}
-
-	return
-}
-
 // Test that we can pk-put and pk-get a file whose name is not utf8,
 // that we don't panic in the process and that the results are
 // correct.
 func TestNonUTF8FileName(t *testing.T) {
-	srcDir, cleanup := tempDir(t)
-	defer cleanup()
+	srcDir := t.TempDir()
 
 	base, err := hex.DecodeString(nonUTF8)
 	if err != nil {
@@ -73,8 +58,7 @@ func TestNonUTF8FileName(t *testing.T) {
 	br := strings.Split(out, "\n")[0]
 
 	// pk-put was a success. Can we get the file back in another directory?
-	dstDir, cleanup := tempDir(t)
-	defer cleanup()
+	dstDir := t.TempDir()
 
 	_ = test.MustRunCmd(t, w.Cmd("pk-get", "-o", dstDir, br))
 	_, err = os.Lstat(filepath.Join(dstDir, string(base)))
@@ -92,8 +76,7 @@ func TestNonUTF8SymlinkTarget(t *testing.T) {
 		t.Skip("skipping symlink test on Windows")
 	}
 
-	srcDir, cleanup := tempDir(t)
-	defer cleanup()
+	srcDir := t.TempDir()
 
 	base, err := hex.DecodeString(nonUTF8)
 	if err != nil {
@@ -121,8 +104,7 @@ func TestNonUTF8SymlinkTarget(t *testing.T) {
 	br := strings.Split(out, "\n")[0]
 
 	// See if we can pk-get it back correctly
-	dstDir, cleanup := tempDir(t)
-	defer cleanup()
+	dstDir := t.TempDir()
 
 	_ = test.MustRunCmd(t, w.Cmd("pk-get", "-o", dstDir, br))
 	target, err := os.Readlink(filepath.Join(dstDir, "link"))

--- a/pkg/test/integration/share_test.go
+++ b/pkg/test/integration/share_test.go
@@ -18,7 +18,6 @@ package integration
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -49,11 +48,7 @@ func share(t *testing.T, file string) {
 	out = test.MustRunCmd(t, w.Cmd("pk-put", "share", "-transitive", fileRef))
 	shareRef := strings.Split(out, "\n")[0]
 
-	testDir, err := ioutil.TempDir("", "camli-share-test-")
-	if err != nil {
-		t.Fatalf("ioutil.TempDir(): %v", err)
-	}
-	defer os.RemoveAll(testDir)
+	testDir := t.TempDir()
 
 	// test that we can get it through the share
 	test.MustRunCmd(t, w.Cmd("pk-get", "-o", testDir, "-shared", fmt.Sprintf("%v/share/%v", w.ServerBaseURL(), shareRef)))


### PR DESCRIPTION
We can write less code by using the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete.

Reference: https://pkg.go.dev/testing#T.TempDir