### PR TITLE
fuse: fix panic in Lookup

### DIFF
--- a/pkg/fs/fs.go
+++ b/pkg/fs/fs.go
@@ -150,7 +150,7 @@ func (n *node) Lookup(ctx context.Context, name string) (fusefs.Node, error) {
 	loaded := n.dirents != nil
 	n.dmu.Unlock()
 	if !loaded {
-		n.ReadDirAll(nil)
+		n.ReadDirAll(ctx)
 	}
 
 	n.mu.Lock()


### PR DESCRIPTION
Fixes #1573 

A context was forgotten to be propagated when bumping the `bazil.org/fuse` package.