### PR TITLE
server: fix panic when modtime or time is not in metadata

### DIFF
--- a/pkg/server/download.go
+++ b/pkg/server/download.go
@@ -235,9 +235,12 @@ func fileInfoPacked(ctx context.Context, sh *search.Handler, src blob.Fetcher, r
 		log.Printf("ui: fileInfoPacked: skipping fast path due to error from WholeRefFetcher (%T): %v", src, err)
 		return fileInfo{whyNot: "WholeRefFetcher error"}, false
 	}
-	modtime := fi.ModTime
-	if modtime.IsAnyZero() {
-		modtime = fi.Time
+
+	var modtime time.Time
+	if !fi.ModTime.IsAnyZero() {
+		modtime = fi.ModTime.Time()
+	} else if !fi.Time.IsAnyZero() {
+		modtime = fi.Time.Time()
 	}
 	// TODO(mpl): it'd be nicer to get the FileMode from the describe response,
 	// instead of having to fetch the file schema again, but we don't index the
@@ -252,7 +255,7 @@ func fileInfoPacked(ctx context.Context, sh *search.Handler, src blob.Fetcher, r
 		mime:    fi.MIMEType,
 		name:    fi.FileName,
 		size:    fi.Size,
-		modtime: modtime.Time(),
+		modtime: modtime,
 		mode:    fr.FileMode(),
 		rs:      readerutil.NewFakeSeeker(rc, fi.Size-offset),
 		close:   rc.Close,


### PR DESCRIPTION
Noticed this panic when scrolling: 


```
2022/02/23 17:56:57 http: panic serving 127.0.0.1:42996: runtime error: invalid memory address or nil pointer dereference
goroutine 11142 [running]:
net/http.(*conn).serve.func1(0xc0016a8000)
	/var/home/mhoffm/sdk/go1.16.13/src/net/http/server.go:1805 +0x153
panic(0x14da160, 0x2576e70)
	/var/home/mhoffm/sdk/go1.16.13/src/runtime/panic.go:971 +0x499
perkeep.org/pkg/server.fileInfoPacked(0x1c50250, 0xc000417cc0, 0xc0014c6400, 0x7f57181e9638, 0xc00015d340, 0x0, 0x1c58698, 0xc0009eea00, 0x0, 0x0, ...)
	/var/home/mhoffm/Git/Tools/perkeep.org/pkg/server/download.go:256 +0x5ad
perkeep.org/pkg/server.(*ImageHandler).newFileReader(0xc0016c3830, 0x1c50250, 0xc000417cc0, 0x1c58698, 0xc0009eea00, 0xc000374ea8, 0xc001d15d70, 0xc001d15d70, 0xc0005c8780)
	/var/home/mhoffm/Git/Tools/perkeep.org/pkg/server/image.go:239 +0xb7
perkeep.org/pkg/server.(*ImageHandler).scaleImage(0xc0016c3830, 0x1c50250, 0xc000417cc0, 0x1c58698, 0xc0009eea00, 0x0, 0x0, 0x0)
	/var/home/mhoffm/Git/Tools/perkeep.org/pkg/server/image.go:261 +0x8e
perkeep.org/pkg/server.(*ImageHandler).ServeHTTP.func1(0x14c9e80, 0xc001d593e0, 0xc000425260, 0x53)
	/var/home/mhoffm/Git/Tools/perkeep.org/pkg/server/image.go:383 +0x4e
go4.org/syncutil/singleflight.(*Group).Do(0x25ad0e0, 0xc000425260, 0x53, 0xc0016c3758, 0x1c58698, 0xc0009eea00, 0x0, 0x0)
```

It happens when the image has neither time nor modtime metadata in the index: 

```
2022/02/23 17:56:57 &{FileName:example-cpp.png Size:874960 MIMEType:image/png Time:<nil> ModTime:<nil> WholeRef:sha224-2a53ba7f3d1d61686e6cbf605bca6ec3ca59115838b4b13750046b4a}
```

Added `time.Time{}` as a fallback in that case to fix the panic at least.