### PR TITLE
jsonsign: write armored keyring

### DIFF
--- a/pkg/jsonsign/jsonsign_test.go
+++ b/pkg/jsonsign/jsonsign_test.go
@@ -213,7 +213,7 @@ func TestWriteKeyRing(t *testing.T) {
 		t.Fatalf("WriteKeyRing: %v", err)
 	}
 
-	el, err := openpgp.ReadKeyRing(&buf)
+	el, err := openpgp.ReadArmoredKeyRing(&buf)
 	if err != nil {
 		t.Fatalf("ReadKeyRing: %v", err)
 	}


### PR DESCRIPTION
```
    jsonsign: write armored keyring

    Write Perkeep's keyring as armored for simpler backup to text files.

    The code is backwards-compatible. We try reading the keyring as if it
    was armored and we default to the old format on failure.
```