### PR TITLE
improve docker build times and image size

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 bin/*
 tmp/*
 misc/docker/release/*
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,22 +18,7 @@ WORKDIR /go/src/perkeep.org
 COPY go.mod go.sum ./
 RUN go mod download
 
-# Add each directory separately, so our context doesn't include the
-# Dockerfile itself, to permit quicker iteration with docker's
-# caching.
-ADD .git /go/src/perkeep.org/.git
-add app /go/src/perkeep.org/app
-ADD clients /go/src/perkeep.org/clients
-ADD cmd /go/src/perkeep.org/cmd
-ADD config /go/src/perkeep.org/config
-ADD dev /go/src/perkeep.org/dev
-ADD doc /go/src/perkeep.org/doc
-ADD internal /go/src/perkeep.org/internal
-ADD pkg /go/src/perkeep.org/pkg
-ADD server /go/src/perkeep.org/server
-ADD website /go/src/perkeep.org/website
-ADD make.go /go/src/perkeep.org/make.go
-ADD VERSION /go/src/perkeep.org/VERSION
+COPY . .
 
 RUN go run make.go -v
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,11 @@ MAINTAINER Perkeep Authors <perkeep@googlegroups.com>
 
 ENV DEBIAN_FRONTEND noninteractive
 
+WORKDIR /go/src/perkeep.org
+
+COPY go.mod go.sum ./
+RUN go mod download
+
 # Add each directory separately, so our context doesn't include the
 # Dockerfile itself, to permit quicker iteration with docker's
 # caching.
@@ -29,10 +34,6 @@ ADD server /go/src/perkeep.org/server
 ADD website /go/src/perkeep.org/website
 ADD make.go /go/src/perkeep.org/make.go
 ADD VERSION /go/src/perkeep.org/VERSION
-ADD go.mod /go/src/perkeep.org/go.mod
-ADD go.sum /go/src/perkeep.org/go.sum
-
-WORKDIR /go/src/perkeep.org
 
 RUN go run make.go -v
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,34 +7,11 @@
 # misc/docker/heiftojpeg's Dockerfile entirely. Not decided best way.
 # TODO: likewise, djpeg binary? maybe. https://perkeep.org/issue/1142
 
-FROM buildpack-deps:stretch-scm AS pkbuild
+FROM golang:1.18 AS pkbuild
 
 MAINTAINER Perkeep Authors <perkeep@googlegroups.com>
 
 ENV DEBIAN_FRONTEND noninteractive
-
-# gcc for cgo, sqlite
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		g++ \
-		gcc \
-		libc6-dev \
-		make \
-		pkg-config \
-		libsqlite3-dev
-
-ENV GOLANG_VERSION 1.16.6
-
-WORKDIR /usr/local
-RUN wget -O go.tgz https://dl.google.com/go/go${GOLANG_VERSION}.linux-amd64.tar.gz
-RUN echo "be333ef18b3016e9d7cb7b1ff1fdb0cac800ca0be4cf2290fe613b3d069dfe0d go.tgz" | sha256sum -c -
-RUN tar -zxvf go.tgz
-
-ENV GOROOT /usr/local/go
-ENV GOPATH /go
-ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
-
-RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
-WORKDIR $GOPATH
 
 # Add each directory separately, so our context doesn't include the
 # Dockerfile itself, to permit quicker iteration with docker's

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,12 +24,8 @@ RUN go run make.go -v
 
 
 
-FROM debian:stretch
+FROM gcr.io/distroless/base
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-                libsqlite3-dev ca-certificates && rm -rf /var/lib/apt/lists/*
-
-RUN mkdir -p /home/keepy/bin
 ENV HOME /home/keepy
 ENV PATH /home/keepy/bin:$PATH
 
@@ -39,4 +35,4 @@ COPY --from=pkbuild /go/bin/perkeepd /home/keepy/bin/
 EXPOSE 80 443 3179 8080
 
 WORKDIR /home/keepy
-CMD /bin/bash
+CMD ["perkeepd"]


### PR DESCRIPTION
This updates the main perkeep Dockerfile in various ways (see individual commits) to improve both build time and image size by ~40% each.

I switched from running perkeep directly on Debian to Docker a few weeks ago with these changes, and it's been working well for me.  One small downside is that the distroless base image no longer has a shell that can be used to explore or debug the container, but I've personally never used that anyway.  Not sure if others have, hopefully that's okay?