### PR TITLE
geocode: add support for openstreetmap geocoding api

### DIFF
--- a/doc/geocoding.md
+++ b/doc/geocoding.md
@@ -3,12 +3,12 @@
 Geocoding is the process of converting a location name (like `nyc` or
 `Argentina`) into GPS coordinates and bounding box(es).
 
-Perkeep's location search currently requires Google's Geocoding API,
-which now requires an API key. We do not currently provide a default,
-shared API key to use by default. (We might in the future.)
+Perkeep's location search will use Google's Geocoding API if a key is provided,
+otherwise it falls back to using OpenStreetMap's API.
 
-For now, you need to manually get your own Geocoding API key from Google and place it
-in your Perkeep configuration directory (run `pk env configdir` to
-find your configuration directory) in a file named `google-geocode.key`.
+To use Google's Geocoding API, you need to manually get your own API key from
+Google and place it in your Perkeep configuration directory (run `pk env
+configdir` to find your configuration directory) in a file named
+`google-geocode.key`.
 
-To get the key, see https://developers.google.com/maps/documentation/geocoding/start#get-a-key
+To get the Google API key, see https://developers.google.com/maps/documentation/geocoding/get-api-key

--- a/internal/geocode/geocode_test.go
+++ b/internal/geocode/geocode_test.go
@@ -236,3 +236,57 @@ var googleUSA = `
    "status" : "OK"
 }
 `
+
+func TestDecodeOpenStreetMapResponse(t *testing.T) {
+	tests := []struct {
+		name string
+		res  string
+		want []Rect
+	}{
+		{
+			name: "moscow",
+			res:  openstreetmapMoscow,
+			want: []Rect{
+				{
+					NorthEast: LatLong{pf("55.9577717"), pf("37.9674277")},
+					SouthWest: LatLong{pf("55.4913076"), pf("37.290502")},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		rects, err := decodeOpenStreetMapResponse(strings.NewReader(tt.res))
+		if err != nil {
+			t.Errorf("Decoding %s: %v", tt.name, err)
+			continue
+		}
+		if !reflect.DeepEqual(rects, tt.want) {
+			t.Errorf("Test %s: wrong rects\n Got %#v\nWant %#v", tt.name, rects, tt.want)
+		}
+	}
+}
+
+// https://nominatim.openstreetmap.org/search?format=json&limit=1&q=moscow
+var openstreetmapMoscow = `
+[
+   {
+     "place_id": 282700412,
+     "licence": "Data © OpenStreetMap contributors, ODbL 1.0. https://osm.org/copyright",
+     "osm_type": "relation",
+     "osm_id": 2555133,
+     "boundingbox": [
+       "55.4913076",
+       "55.9577717",
+       "37.290502",
+       "37.9674277"
+     ],
+     "lat": "55.7504461",
+     "lon": "37.6174943",
+     "display_name": "Москва, Центральный федеральный округ, Россия",
+     "class": "place",
+     "type": "city",
+     "importance": 0.7908193282833463,
+     "icon": "https://nominatim.openstreetmap.org/ui/mapicons//poi_place_city.p.20.png"
+   }
+ ]
+ `

--- a/pkg/server/help.go
+++ b/pkg/server/help.go
@@ -57,6 +57,10 @@ const helpHTML string = `<html>
 
 			<h3>Anything Else?</h3>
 			<p>See the Perkeep <a href='https://perkeep.org/doc/'>online documentation</a> and <a href='https://perkeep.org/community'>community contacts</a>.</p>
+
+			<h3>Attribution</h3>
+			<p>Various mapping data and services <a href="https://osm.org/copyright">copyright OpenStreetMap contributors</a>, ODbL 1.0.</p>
+
 		</body>
 	</html>`
 

--- a/server/perkeepd/perkeepd.go
+++ b/server/perkeepd/perkeepd.go
@@ -382,9 +382,9 @@ func checkGeoKey() error {
 	}
 	if env.OnGCE() {
 		keyPath = strings.TrimPrefix(keyPath, "/gcs/")
-		return fmt.Errorf("for location related requests to properly work, you need to create a Google Geocoding API Key (see https://developers.google.com/maps/documentation/geocoding/get-api-key ), and save it in your VM's configuration bucket as: %v", keyPath)
+		return fmt.Errorf("using OpenStreetMap for location related requests. To use the Google Geocoding API, create a key (see https://developers.google.com/maps/documentation/geocoding/get-api-key ) and save it in your VM's configuration bucket as: %v", keyPath)
 	}
-	return fmt.Errorf("for location related requests to properly work, you need to create a Google Geocoding API Key (see https://developers.google.com/maps/documentation/geocoding/get-api-key ), and save it in Perkeep's configuration directory as: %v", keyPath)
+	return fmt.Errorf("using OpenStreetMap for location related requests. To use the Google Geocoding API, create a key (see https://developers.google.com/maps/documentation/geocoding/get-api-key ) and save it in Perkeep's configuration directory as: %v", keyPath)
 }
 
 // main wraps Main so tests (which generate their own func main) can still run Main.


### PR DESCRIPTION
Use the OpenStreetMap [Nominatim API](https://wiki.openstreetmap.org/wiki/Nominatim) when no Google Geocoding API key is present.  Nominatim does not require any keys, so we can safely enable it by default, though their terms request no more than 1 qps, which should probably be fine?

Docs and log messages are updated to reflect this behavior.  OSM Attribution is added to the help page, which is not the best but probably okay for now.  In a future change, I'd like to change the About alert to a static page, and move licensing information there.

Fixes #1342 