### PR TITLE
fuse: misc fixes

### DIFF
--- a/cmd/pk-mount/pkmount.go
+++ b/cmd/pk-mount/pkmount.go
@@ -1,3 +1,4 @@
+//go:build linux || darwin
 // +build linux darwin
 
 /*

--- a/cmd/pk-mount/pkmount_other.go
+++ b/cmd/pk-mount/pkmount_other.go
@@ -1,3 +1,4 @@
+//go:build !linux && !darwin
 // +build !linux,!darwin
 
 /*

--- a/pkg/client/get.go
+++ b/pkg/client/get.go
@@ -135,7 +135,7 @@ func (c *Client) fetchVia(ctx context.Context, b blob.Ref, v []blob.Ref) (body i
 			size = uint32(n)
 			reader, closer = &buf, types.NopCloser
 		} else {
-			return nil, 0, fmt.Errorf("Error reading %s: %v", b, err)
+			return nil, 0, fmt.Errorf("Error reading %s: %w", b, err)
 		}
 	}
 

--- a/pkg/client/upload.go
+++ b/pkg/client/upload.go
@@ -212,7 +212,7 @@ func (c *Client) doStat(ctx context.Context, blobs []blob.Ref, wait time.Duratio
 		resp, err = c.httpClient.Do(req)
 	}
 	if err != nil {
-		return fmt.Errorf("stat HTTP error: %v", err)
+		return fmt.Errorf("stat HTTP error: %w", err)
 	}
 	if resp.Body != nil {
 		defer resp.Body.Close()
@@ -303,7 +303,7 @@ func (c *Client) Upload(ctx context.Context, h *UploadHandle) (*PutResult, error
 
 		resp, err := c.doReqGated(req)
 		if err != nil {
-			return errorf("stat http error: %v", err)
+			return errorf("stat http error: %w", err)
 		}
 		defer resp.Body.Close()
 
@@ -368,13 +368,13 @@ func (c *Client) Upload(ctx context.Context, h *UploadHandle) (*PutResult, error
 	req.ContentLength = getMultipartOverhead() + bodySize + int64(len(blobrefStr))*2
 	resp, err := c.doReqGated(req)
 	if err != nil {
-		return errorf("upload http error: %v", err)
+		return errorf("upload http error: %w", err)
 	}
 	defer resp.Body.Close()
 
 	// check error from earlier copy
 	if err := <-copyResult; err != nil {
-		return errorf("failed to copy contents into multipart writer: %v", err)
+		return errorf("failed to copy contents into multipart writer: %w", err)
 	}
 
 	// The only valid HTTP responses are 200 and 303.
@@ -390,18 +390,18 @@ func (c *Client) Upload(ctx context.Context, h *UploadHandle) (*PutResult, error
 		baseURL, _ := url.Parse(uploadURL)
 		absURL, err := baseURL.Parse(otherLocation)
 		if err != nil {
-			return errorf("303 Location URL relative resolve error: %v", err)
+			return errorf("303 Location URL relative resolve error: %w", err)
 		}
 		otherLocation = absURL.String()
 		resp, err = http.Get(otherLocation)
 		if err != nil {
-			return errorf("error following 303 redirect after upload: %v", err)
+			return errorf("error following 303 redirect after upload: %w", err)
 		}
 	}
 
 	var ures protocol.UploadResponse
 	if err := httputil.DecodeJSON(resp, &ures); err != nil {
-		return errorf("error in upload response: %v", err)
+		return errorf("error in upload response: %w", err)
 	}
 
 	if ures.ErrorText != "" {

--- a/pkg/fs/at.go
+++ b/pkg/fs/at.go
@@ -1,3 +1,4 @@
+//go:build linux || darwin
 // +build linux darwin
 
 /*

--- a/pkg/fs/debug.go
+++ b/pkg/fs/debug.go
@@ -1,3 +1,4 @@
+//go:build linux || darwin
 // +build linux darwin
 
 /*

--- a/pkg/fs/mut_test.go
+++ b/pkg/fs/mut_test.go
@@ -1,3 +1,4 @@
+//go:build linux || darwin
 // +build linux darwin
 
 /*

--- a/pkg/fs/time.go
+++ b/pkg/fs/time.go
@@ -1,3 +1,4 @@
+//go:build linux || darwin
 // +build linux darwin
 
 /*

--- a/pkg/fs/time_test.go
+++ b/pkg/fs/time_test.go
@@ -1,3 +1,4 @@
+//go:build linux || darwin
 // +build linux darwin
 
 /*

--- a/pkg/fs/xattr.go
+++ b/pkg/fs/xattr.go
@@ -1,3 +1,4 @@
+//go:build linux || darwin
 // +build linux darwin
 
 /*
@@ -81,7 +82,7 @@ func (x *xattr) set(ctx context.Context, req *fuse.SetxattrRequest) error {
 	_, err := x.fs.client.UploadAndSignBlob(ctx, claim)
 	if err != nil {
 		Logger.Printf("Error setting xattr: %v", err)
-		return fuse.EIO
+		return handleEIOorEINTR(err)
 	}
 
 	val := make([]byte, len(req.Xattr))
@@ -101,7 +102,7 @@ func (x *xattr) remove(ctx context.Context, req *fuse.RemovexattrRequest) error 
 
 	if err != nil {
 		Logger.Printf("Error removing xattr: %v", err)
-		return fuse.EIO
+		return handleEIOorEINTR(err)
 	}
 
 	x.mu.Lock()

--- a/pkg/fs/z_test.go
+++ b/pkg/fs/z_test.go
@@ -1,3 +1,4 @@
+//go:build linux || darwin
 // +build linux darwin
 
 /*

--- a/pkg/schema/filereader.go
+++ b/pkg/schema/filereader.go
@@ -76,12 +76,12 @@ func NewFileReader(ctx context.Context, fetcher blob.Fetcher, fileBlobRef blob.R
 	}
 	rc, _, err := fetcher.Fetch(ctx, fileBlobRef)
 	if err != nil {
-		return nil, fmt.Errorf("schema/filereader: fetching file schema blob: %v", err)
+		return nil, fmt.Errorf("schema/filereader: fetching file schema blob: %w", err)
 	}
 	defer rc.Close()
 	ss, err := parseSuperset(rc)
 	if err != nil {
-		return nil, fmt.Errorf("schema/filereader: decoding file schema blob: %v", err)
+		return nil, fmt.Errorf("schema/filereader: decoding file schema blob: %w", err)
 	}
 	ss.BlobRef = fileBlobRef
 	if ss.Type != "file" && ss.Type != "bytes" {
@@ -89,7 +89,7 @@ func NewFileReader(ctx context.Context, fetcher blob.Fetcher, fileBlobRef blob.R
 	}
 	fr, err := ss.NewFileReader(fetcher)
 	if err != nil {
-		return nil, fmt.Errorf("schema/filereader: creating FileReader for %s: %v", fileBlobRef, err)
+		return nil, fmt.Errorf("schema/filereader: creating FileReader for %s: %w", fileBlobRef, err)
 	}
 	return fr, nil
 }
@@ -290,7 +290,7 @@ func (fr *FileReader) getSuperset(ctx context.Context, br blob.Ref) (*superset, 
 		}
 		rc, _, err := fr.fetcher.Fetch(ctx, br)
 		if err != nil {
-			return nil, fmt.Errorf("schema/filereader: fetching file schema blob: %v", err)
+			return nil, fmt.Errorf("schema/filereader: fetching file schema blob: %w", err)
 		}
 		defer rc.Close()
 		ss, err = parseSuperset(rc)

--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -231,7 +231,7 @@ func NewDirectoryEntryFromBlobRef(ctx context.Context, fetcher blob.Fetcher, blo
 	ss := new(superset)
 	err := ss.setFromBlobRef(ctx, fetcher, blobRef)
 	if err != nil {
-		return nil, fmt.Errorf("schema/filereader: can't fill superset: %v", err)
+		return nil, fmt.Errorf("schema/filereader: can't fill superset: %w", err)
 	}
 	return newDirectoryEntry(fetcher, ss)
 }
@@ -1011,7 +1011,7 @@ func FileTime(f io.ReaderAt) (time.Time, error) {
 		if osf, ok := f.(*os.File); ok {
 			fi, err := osf.Stat()
 			if err != nil {
-				return ct, fmt.Errorf("Failed to find a modtime: stat: %v", err)
+				return ct, fmt.Errorf("Failed to find a modtime: stat: %w", err)
 			}
 			return fi.ModTime(), nil
 		}


### PR DESCRIPTION
This should fix some of the flakiness in the `perkeep.org/pkg/fs` tests.

* propagate more context cancelations from pkg/client
* convert ErrCancel to fuse.EINTR to enable clients to handle interrupts
* improve interrupt handling in fs_test.go
* fix race in mutdir between rename and first populate