### PR TITLE
images: fix crash when decoding with djpeg fails

### DIFF
--- a/internal/images/images.go
+++ b/internal/images/images.go
@@ -497,6 +497,9 @@ func decode(r io.Reader, opts *DecodeOpts, swapDimensions bool) (im image.Image,
 			case fastjpeg.DjpegFailedError:
 				log.Printf("Retrying with jpeg.Decode, because djpeg failed with: %v", err)
 				im, err = jpeg.Decode(io.MultiReader(&buf, mr))
+				if err != nil {
+					return nil, format, err, false
+				}
 			case nil:
 				// fallthrough to rescale() below.
 			default:


### PR DESCRIPTION
The test image crashed on my perkeep instance with 

```
Jul 09 12:14:01 ubuntu perkeepd[74240]: 2022/07/09 12:14:01 Retrying with jpeg.Decode, because djpeg failed with: exit status 2: Invalid SOS parameters for sequential JPEG
Jul 09 12:14:02 ubuntu perkeepd[74240]: 2022/07/09 12:14:02 http: panic serving 192.168.178.38:44074: runtime error: invalid memory address or nil pointer dereference
Jul 09 12:14:02 ubuntu perkeepd[74240]: goroutine 7711129 [running]:
Jul 09 12:14:02 ubuntu perkeepd[74240]: net/http.(*conn).serve.func1(0x4020f57e00)
Jul 09 12:14:02 ubuntu perkeepd[74240]:         /home/micha/.local/go/src/net/http/server.go:1802 +0xe4
Jul 09 12:14:02 ubuntu perkeepd[74240]: panic({0xea4340, 0x203d300})
Jul 09 12:14:02 ubuntu perkeepd[74240]:         /home/micha/.local/go/src/runtime/panic.go:1052 +0x2b4
Jul 09 12:14:02 ubuntu perkeepd[74240]: perkeep.org/internal/images.rescale({0x0, 0x0}, 0x620, 0x3e8)
Jul 09 12:14:02 ubuntu perkeepd[74240]:         /home/micha/git/perkeep.org/internal/images/images.go:311 +0x20
Jul 09 12:14:02 ubuntu perkeepd[74240]: perkeep.org/internal/images.decode({0x1648da0, 0x402cee99e0}, 0x4018765360, 0x0)
Jul 09 12:14:02 ubuntu perkeepd[74240]:         /home/micha/git/perkeep.org/internal/images/images.go:505 +0x748
Jul 09 12:14:02 ubuntu perkeepd[74240]: perkeep.org/internal/images.Decode({0x1648da0, 0x402cee98c0}, 0x4018765360)
Jul 09 12:14:02 ubuntu perkeepd[74240]:         /home/micha/git/perkeep.org/internal/images/images.go:596 +0x2ac
Jul 09 12:14:02 ubuntu perkeepd[74240]: perkeep.org/pkg/server.(*ImageHandler).scaleImage(0x4018765758, {0x166c110, 0x4019518a80}, {{0x167a6d8, 0x401fd97a40}})
Jul 09 12:14:02 ubuntu perkeepd[74240]:         /home/micha/git/perkeep.org/pkg/server/image.go:297 +0x2e4
Jul 09 12:14:02 ubuntu perkeepd[74240]: perkeep.org/pkg/server.(*ImageHandler).ServeHTTP.func1()
Jul 09 12:14:02 ubuntu perkeepd[74240]:         /home/micha/git/perkeep.org/pkg/server/image.go:383 +0x48
```

because error during fallback decoding was not handled properly.

Furthermore status code 2 for djpeg just means warning, the output is still usable  ( at least in my experiments it produced good results )