### PR TITLE
android: fix upload thread restarts

### DIFF
--- a/clients/android/app/src/main/java/org/camlistore/UploadService.java
+++ b/clients/android/app/src/main/java/org/camlistore/UploadService.java
@@ -492,13 +492,8 @@ public class UploadService extends Service {
             if (mFileBytesRemain.isEmpty()) {
                 // Fill up the percentage bars, since we could get
                 // this event before the periodic stats event.
-                // And at the end, we could kill pk-put between
-                // getting the final "file uploaded" event and the final
-                // stats event.
                 mFilesUploaded = mFilesTotal;
                 mBytesUploaded = mBytesTotal;
-                mNotificationManager.cancel(NOTIFY_ID_UPLOADING);
-                stopUploadThread();
             }
             mQueueList.remove(qf); // TODO: ghetto, linear scan
         }


### PR DESCRIPTION
Before this change there is a race between queuing files and uploading them (very pronounced when pressing `Upload All` with most files in the havecache). When starting to enqueue files, if pk-put drains the queue faster we end up restarting the upload thread very frequently leading to `input/output error: file busy` when trying to create/open the havecache during pk-put start. I have not run into this error again with this change.