### PR TITLE
camlistore.org -> perkeep.org

### DIFF
--- a/app/publisher/main.go
+++ b/app/publisher/main.go
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 // The publisher command is a server application to publish items from a
-// Perkeep server. See also https://camlistore.org/doc/publishing
+// Perkeep server. See also https://perkeep.org/doc/publishing
 package main
 
 import (

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 // Package app provides helpers for server applications interacting
 // with Perkeep.
-// See also https://camlistore.org/doc/app-environment for the related
+// See also https://perkeep.org/doc/app-environment for the related
 // variables.
 package app // import "perkeep.org/pkg/app"
 

--- a/pkg/buildinfo/buildinfo.go
+++ b/pkg/buildinfo/buildinfo.go
@@ -22,7 +22,7 @@ import "flag"
 // GitInfo is either the empty string (the default)
 // or is set to the git hash of the most recent commit
 // using the -X linker flag. For example, it's set like:
-// $ go install --ldflags="-X camlistore.org/pkg/buildinfo.GitInfo "`./misc/gitversion` camlistore.org/server/perkeepd
+// $ go install --ldflags="-X perkeep.org/pkg/buildinfo.GitInfo "`./misc/gitversion` perkeep.org/server/perkeepd
 var GitInfo string
 
 // Version is a string like "0.10" or "1.0", if applicable.

--- a/pkg/client/upload.go
+++ b/pkg/client/upload.go
@@ -135,7 +135,7 @@ func NewUploadHandleFromString(data string) *UploadHandle {
 	return &UploadHandle{BlobRef: bref, Size: uint32(len(data)), Contents: r}
 }
 
-// TODO(bradfitz): delete most of this. use new camlistore.org/pkg/blobserver/protocol types instead
+// TODO(bradfitz): delete most of this. use new perkeep.org/pkg/blobserver/protocol types instead
 // of a map[string]interface{}.
 func (c *Client) responseJSONMap(requestName string, resp *http.Response) (map[string]interface{}, error) {
 	if resp.StatusCode != 200 {

--- a/pkg/server/app/app.go
+++ b/pkg/server/app/app.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 // Package app helps with configuring and starting server applications
 // from Perkeep.
-// See also https://camlistore.org/doc/app-environment for the related
+// See also https://perkeep.org/doc/app-environment for the related
 // variables.
 package app // import "perkeep.org/pkg/server/app"
 

--- a/pkg/server/wizard.go
+++ b/pkg/server/wizard.go
@@ -47,7 +47,7 @@ func (sh *SetupHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 				"</body></html>\n")
 		return
 	}
-	http.Redirect(rw, req, "https://camlistore.org/doc/server-config", http.StatusMovedPermanently)
+	http.Redirect(rw, req, "https://perkeep.org/doc/server-config", http.StatusMovedPermanently)
 	return
 
 	// TODO: this file and the code in wizard-html.go is outdated. Anyone interested enough

--- a/pkg/types/camtypes/errors.go
+++ b/pkg/types/camtypes/errors.go
@@ -29,7 +29,7 @@ var camErrors = map[string]*camErr{}
 
 var (
 	ErrClientNoServer = addCamError("client-no-server", funcStr(func() string {
-		return fmt.Sprintf("No valid server defined. It can be set with the CAMLI_SERVER environment variable, or the --server flag, or in the \"servers\" section of %q (see https://camlistore.org/doc/client-config).", osutil.UserClientConfigPath())
+		return fmt.Sprintf("No valid server defined. It can be set with the CAMLI_SERVER environment variable, or the --server flag, or in the \"servers\" section of %q (see https://perkeep.org/doc/client-config).", osutil.UserClientConfigPath())
 	}))
 	ErrClientNoPublicKey = addCamError("client-no-public-key", str("No public key configured: see 'pk-put init'."))
 )
@@ -60,7 +60,7 @@ func (ce *camErr) Warn() {
 }
 
 func (ce *camErr) URL() string {
-	return fmt.Sprintf("https://camlistore.org/err/%s", ce.key)
+	return fmt.Sprintf("https://perkeep.org/err/%s", ce.key)
 }
 
 // Err returns the error registered for key.

--- a/pkg/types/serverconfig/config.go
+++ b/pkg/types/serverconfig/config.go
@@ -106,7 +106,7 @@ type Config struct {
 }
 
 // App holds the common configuration values for apps and the app handler.
-// See https://camlistore.org/doc/app-environment
+// See https://perkeep.org/doc/app-environment
 type App struct {
 	// Listen is the address (of the form host|ip:port) on which the app
 	// will listen. It defines CAMLI_APP_LISTEN.
@@ -183,7 +183,7 @@ type ScanCab struct {
 	// Auth is the authentication scheme and values to access the app.
 	// It defaults to the server config auth.
 	// Common uses are HTTP basic auth: "userpass:foo:bar", or no authentication:
-	// "none". See https://camlistore.org/pkg/auth for other schemes.
+	// "none". See https://perkeep.org/pkg/auth for other schemes.
 	Auth string `json:"auth"`
 
 	// App is for the common apps and app handler configuration.


### PR DESCRIPTION
fix up some links

There are still some references to camlistore.org that I don't understand so left alone.