### PR TITLE
all: Replace deprecated io/ioutil with io and os

### DIFF
--- a/app/publisher/js/file.go
+++ b/app/publisher/js/file.go
@@ -23,7 +23,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"html"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"path"
@@ -263,7 +263,7 @@ func getFullRef(scheme, host, pathPrefix, digestPrefix string) (blob.Ref, error)
 		return br, fmt.Errorf("search error: %v", resp.Status)
 	}
 	defer resp.Body.Close()
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return br, err
 	}
@@ -288,7 +288,7 @@ func (fic fileItemContainer) describe(pn blob.Ref) (*SearchResult, error) {
 		return nil, fmt.Errorf("search error: %v", resp.Status)
 	}
 	defer resp.Body.Close()
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -312,7 +312,7 @@ func (fic fileItemContainer) getPeers(around blob.Ref, limit int) (*SearchResult
 		return nil, fmt.Errorf("search error: %v", resp.Status)
 	}
 	defer resp.Body.Close()
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/app/publisher/js/members.go
+++ b/app/publisher/js/members.go
@@ -23,7 +23,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"html"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -202,7 +202,7 @@ func (bic blobItemContainer) getMembers() (items []*blobItem, cont string, err e
 		return nil, "", fmt.Errorf("search error: %v", resp.Status)
 	}
 	defer resp.Body.Close()
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, "", err
 	}

--- a/app/publisher/main.go
+++ b/app/publisher/main.go
@@ -29,7 +29,6 @@ import (
 	"html/template"
 	"io"
 	"io/fs"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"net/url"
@@ -159,7 +158,7 @@ func (ph *publishHandler) setMasterQuery(topNode blob.Ref) error {
 		return err
 	}
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}
@@ -188,7 +187,7 @@ func (ph *publishHandler) refreshMasterQuery() error {
 		// request suppression. let's not consider it an error.
 		return nil
 	}
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}
@@ -419,7 +418,7 @@ func goTemplate(files fs.FS, templateFile string) (*template.Template, error) {
 		return nil, fmt.Errorf("Could not open template %v: %v", templateFile, err)
 	}
 	defer f.Close()
-	templateBytes, err := ioutil.ReadAll(f)
+	templateBytes, err := io.ReadAll(f)
 	if err != nil {
 		return nil, fmt.Errorf("Could not read template %v: %v", templateFile, err)
 	}

--- a/app/scanningcabinet/handler.go
+++ b/app/scanningcabinet/handler.go
@@ -22,7 +22,6 @@ import (
 	"html/template"
 	"io"
 	"io/fs"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path"
@@ -337,7 +336,7 @@ func (h *handler) handleUpload(w http.ResponseWriter, r *http.Request) {
 				logf("form field %q provided in upload, but ignored", part.FormName())
 				continue
 			}
-			creationParam, err := ioutil.ReadAll(part)
+			creationParam, err := io.ReadAll(part)
 			if err != nil {
 				httputil.ServeError(w, r, fmt.Errorf("could not read provided creation time: %v", err))
 				return

--- a/app/scanningcabinet/scancab/scancab.go
+++ b/app/scanningcabinet/scancab/scancab.go
@@ -23,7 +23,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"mime/multipart"
 	"net/http"
@@ -93,7 +92,7 @@ func getUploadURL() (string, error) {
 		return "", err
 	}
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", err
 	}
@@ -164,7 +163,7 @@ func uploadOne(filename string) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	tmpDir, err := ioutil.TempDir("", "scancabcli")
+	tmpDir, err := os.MkdirTemp("", "scancabcli")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -423,7 +422,7 @@ func checkSanity() {
 	if !*flagLoop && *flagUpload == "" {
 		if *flagDevice == "" {
 			deviceFile := path.Join(confDir, "device")
-			device, err := ioutil.ReadFile(deviceFile)
+			device, err := os.ReadFile(deviceFile)
 			if err != nil {
 				log.Printf("error reading device conf file %v: %v", deviceFile, err)
 				usageAndDie(fmt.Sprintf("Please specify your scanning device with the -device option, or in %v", deviceFile))
@@ -444,7 +443,7 @@ func checkSanity() {
 	if !*flagADF {
 		if *flagURL == "" {
 			urlFile := path.Join(confDir, "url")
-			URL, err := ioutil.ReadFile(urlFile)
+			URL, err := os.ReadFile(urlFile)
 			if err != nil {
 				log.Printf("error reading url file %v: %v", urlFile, err)
 				usageAndDie(fmt.Sprintf("Please specify the scanning cabinet app URL with the -url option, or in %v", urlFile))
@@ -453,7 +452,7 @@ func checkSanity() {
 		}
 		if *flagUsername == "" {
 			userFile := path.Join(confDir, "user")
-			username, err := ioutil.ReadFile(userFile)
+			username, err := os.ReadFile(userFile)
 			if err != nil {
 				log.Printf("error reading username file %v: %v", userFile, err)
 				usageAndDie(fmt.Sprintf("Please specify your username with the -user option, or in %v", userFile))
@@ -462,7 +461,7 @@ func checkSanity() {
 		}
 		if *flagPassword == "" {
 			passFile := path.Join(confDir, "password")
-			password, err := ioutil.ReadFile(passFile)
+			password, err := os.ReadFile(passFile)
 			if err != nil {
 				log.Printf("error reading password file %v: %v", passFile, err)
 				usageAndDie(fmt.Sprintf("Please specify your password with the -pass option, or in %v", passFile))

--- a/clients/android/build-in-docker.go
+++ b/clients/android/build-in-docker.go
@@ -25,7 +25,6 @@ import (
 	"bufio"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -111,7 +110,7 @@ func goVersion() string {
 // getVersion returns the version of Perkeep. Either from a VERSION file at the root,
 // or from git.
 func getVersion() string {
-	slurp, err := ioutil.ReadFile(filepath.Join(pkDir, "VERSION"))
+	slurp, err := os.ReadFile(filepath.Join(pkDir, "VERSION"))
 	if err == nil {
 		return strings.TrimSpace(string(slurp))
 	}

--- a/cmd/pk-mount/pkmount.go
+++ b/cmd/pk-mount/pkmount.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 	"os/exec"
@@ -102,7 +102,7 @@ func main() {
 			log.Printf("no mount point given; using /pk")
 			mountPoint = "/pk"
 		} else {
-			mountPoint, err = ioutil.TempDir("", "pk-mount")
+			mountPoint, err = os.MkdirTemp("", "pk-mount")
 			if err != nil {
 				log.Fatal(err)
 			}
@@ -179,7 +179,7 @@ func main() {
 	if *debug {
 		fuse.Debug = func(msg interface{}) { log.Print(msg) }
 	} else {
-		fs.Logger.SetOutput(ioutil.Discard)
+		fs.Logger.SetOutput(io.Discard)
 	}
 
 	// This doesn't appear to work on OS X:

--- a/cmd/pk-put/camput_test.go
+++ b/cmd/pk-put/camput_test.go
@@ -19,7 +19,6 @@ package main
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -126,7 +125,7 @@ func testWithTempDir(t *testing.T, fn func(tempDir string)) {
 	mustMkdir(t, confDir, 0700)
 	defer os.Setenv("CAMLI_CONFIG_DIR", os.Getenv("CAMLI_CONFIG_DIR"))
 	os.Setenv("CAMLI_CONFIG_DIR", confDir)
-	if err := ioutil.WriteFile(filepath.Join(confDir, "client-config.json"), []byte("{}"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(confDir, "client-config.json"), []byte("{}"), 0644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -171,7 +170,7 @@ func TestUploadDirectories(t *testing.T) {
 			mustMkdir(t, dirPath, 0700)
 			for _, baseFile := range []string{"file.txt", "FILE.txt"} {
 				filePath := filepath.Join(dirPath, baseFile)
-				if err := ioutil.WriteFile(filePath, []byte("some file contents "+filePath), 0600); err != nil {
+				if err := os.WriteFile(filePath, []byte("some file contents "+filePath), 0600); err != nil {
 					t.Fatalf("error writing to %s: %v", filePath, err)
 				}
 				t.Logf("Wrote file %s", filePath)

--- a/cmd/pk-put/discard.go
+++ b/cmd/pk-put/discard.go
@@ -19,7 +19,6 @@ package main
 import (
 	"context"
 	"io"
-	"io/ioutil"
 
 	"perkeep.org/pkg/blob"
 	"perkeep.org/pkg/blobserver"
@@ -30,7 +29,7 @@ type discardStorage struct {
 }
 
 func (discardStorage) ReceiveBlob(ctx context.Context, br blob.Ref, r io.Reader) (sb blob.SizedRef, err error) {
-	n, err := io.Copy(ioutil.Discard, r)
+	n, err := io.Copy(io.Discard, r)
 	return blob.SizedRef{Ref: br, Size: uint32(n)}, err
 }
 

--- a/cmd/pk-put/files.go
+++ b/cmd/pk-put/files.go
@@ -23,7 +23,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -486,7 +485,7 @@ func (up *Uploader) wholeFileDigest(fullPath string) ([]blob.Ref, error) {
 	defer file.Close()
 	td := hashutil.NewTrackDigestReader(file)
 	td.DoLegacySHA1 = up.doLegacySHA1
-	_, err = io.Copy(ioutil.Discard, td)
+	_, err = io.Copy(io.Discard, td)
 	atomic.AddInt64(&atomicDigestOps, 1)
 	if err != nil {
 		return nil, err

--- a/cmd/pk-put/init.go
+++ b/cmd/pk-put/init.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -192,7 +191,7 @@ func (c *initCmd) writeConfig(cc *clientconfig.Config) error {
 	if err != nil {
 		log.Fatalf("JSON serialization error: %v", err)
 	}
-	if err := ioutil.WriteFile(configFilePath, jsonBytes, 0600); err != nil {
+	if err := os.WriteFile(configFilePath, jsonBytes, 0600); err != nil {
 		return fmt.Errorf("could not write client config file %v: %v", configFilePath, err)
 	}
 	log.Printf("Wrote %q; modify as necessary.", configFilePath)

--- a/cmd/pk-put/put.go
+++ b/cmd/pk-put/put.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"net/url"
@@ -78,7 +78,7 @@ func init() {
 			cachelog = log.New(cmdmain.Stderr, "", log.LstdFlags)
 		} else {
 			// It's only ok to do that because we don't expect any cachelog.Fatal* calls.
-			cachelog = log.New(ioutil.Discard, "", log.LstdFlags)
+			cachelog = log.New(io.Discard, "", log.LstdFlags)
 		}
 	}
 

--- a/cmd/pk/search.go
+++ b/cmd/pk/search.go
@@ -20,7 +20,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"strings"
 
@@ -75,7 +75,7 @@ func (c *searchCmd) RunCommand(args []string) error {
 	}
 	q := args[0]
 	if q == "-" {
-		slurp, err := ioutil.ReadAll(cmdmain.Stdin)
+		slurp, err := io.ReadAll(cmdmain.Stdin)
 		if err != nil {
 			return err
 		}

--- a/cmd/pk/searchnames.go
+++ b/cmd/pk/searchnames.go
@@ -20,7 +20,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 
 	"perkeep.org/internal/osutil"
@@ -147,7 +147,7 @@ func getNamedSearch(named string) (getNamedResponse, error) {
 	if err != nil {
 		return gnr, err
 	}
-	result, err := ioutil.ReadAll(reader)
+	result, err := io.ReadAll(reader)
 	if err != nil {
 		return gnr, err
 	}

--- a/dev/devcam/hook.go
+++ b/dev/devcam/hook.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -59,7 +58,7 @@ func (c *hookCmd) installHook() error {
 		_, err := os.Stat(filename)
 		if err == nil {
 			if c.verbose {
-				data, err := ioutil.ReadFile(filename)
+				data, err := os.ReadFile(filename)
 				if err != nil {
 					c.verbosef("reading hook: %v", err)
 				} else if string(data) != hookContent {
@@ -73,7 +72,7 @@ func (c *hookCmd) installHook() error {
 			return fmt.Errorf("checking hook: %v", err)
 		}
 		c.verbosef("installing %s hook", hookFile)
-		if err := ioutil.WriteFile(filename, []byte(hookContent), 0700); err != nil {
+		if err := os.WriteFile(filename, []byte(hookContent), 0700); err != nil {
 			return fmt.Errorf("writing hook: %v", err)
 		}
 	}

--- a/dev/devcam/server.go
+++ b/dev/devcam/server.go
@@ -23,7 +23,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
@@ -430,7 +429,7 @@ func (c *serverCmd) makeThings() error {
 	const importerPrefix = "/importer/"
 	// check that "/importer/" prefix is in config, just in case it ever changes.
 	configFile := filepath.Join(camliSrcRoot, "config", "dev-server-config.json")
-	config, err := ioutil.ReadFile(configFile)
+	config, err := os.ReadFile(configFile)
 	if err != nil {
 		return fmt.Errorf("could not read config file %v: %v", configFile, err)
 	}

--- a/internal/azure/storage/client.go
+++ b/internal/azure/storage/client.go
@@ -27,7 +27,6 @@ import (
 	"fmt"
 	"hash"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"net/url"
@@ -156,7 +155,7 @@ func (c *Client) PutObject(ctx context.Context, key, container string, md5 hash.
 	req.Header.Set("Content-Length", strconv.Itoa(int(size)))
 	req.Header.Set("x-ms-blob-type", "BlockBlob")
 	c.Auth.SignRequest(req)
-	req.Body = ioutil.NopCloser(body)
+	req.Body = io.NopCloser(body)
 
 	res, err := c.transport().RoundTrip(req)
 	if res != nil && res.Body != nil {
@@ -258,7 +257,7 @@ func (c *Client) ListBlobs(ctx context.Context, container string, maxResults int
 }
 
 func getAzureError(operation string, res *http.Response) *Error {
-	body, _ := ioutil.ReadAll(io.LimitReader(res.Body, 1<<20))
+	body, _ := io.ReadAll(io.LimitReader(res.Body, 1<<20))
 	aerr := &Error{
 		Op:     operation,
 		Code:   res.StatusCode,

--- a/internal/closure/jstest/jstest.go
+++ b/internal/closure/jstest/jstest.go
@@ -19,7 +19,6 @@ package jstest // import "perkeep.org/internal/closure/jstest"
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"os/exec"
@@ -89,11 +88,11 @@ func writeDeps(baseJS, targetDir string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("GenDepsWithPath failed: %v", err)
 	}
-	depsFile, err := ioutil.TempFile("", "camlistore_closure_test_runner")
+	depsFile, err := os.CreateTemp("", "camlistore_closure_test_runner")
 	if err != nil {
 		return "", fmt.Errorf("Could not create temp js deps file: %v", err)
 	}
-	err = ioutil.WriteFile(depsFile.Name(), b, 0644)
+	err = os.WriteFile(depsFile.Name(), b, 0644)
 	if err != nil {
 		return "", fmt.Errorf("Could not write js deps file: %v", err)
 	}

--- a/internal/httputil/auth_test.go
+++ b/internal/httputil/auth_test.go
@@ -18,7 +18,7 @@ package httputil
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -117,7 +117,7 @@ func testLoginRequest(t *testing.T, client *http.Client, URL string) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/images/benchfastjpeg_test.go
+++ b/internal/images/benchfastjpeg_test.go
@@ -21,7 +21,6 @@ import (
 	"image"
 	"image/jpeg"
 	"io"
-	"io/ioutil"
 	"testing"
 
 	"perkeep.org/internal/images/fastjpeg"
@@ -104,7 +103,7 @@ func testRun(b testing.TB, decode decodeFunc) {
 	rect := im.Bounds()
 	w, h := 128, 128
 	im = resize.Resize(im, rect, w, h)
-	err = jpeg.Encode(ioutil.Discard, im, nil)
+	err = jpeg.Encode(io.Discard, im, nil)
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/internal/images/images.go
+++ b/internal/images/images.go
@@ -24,7 +24,6 @@ import (
 	"image/draw"
 	"image/jpeg"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -678,7 +677,7 @@ func HEIFToJPEG(fr io.Reader, maxSize *Dimensions) ([]byte, error) {
 		useDocker = true
 	}
 
-	outDir, err := ioutil.TempDir("", "perkeep-heif")
+	outDir, err := os.MkdirTemp("", "perkeep-heif")
 	if err != nil {
 		return nil, err
 	}
@@ -734,5 +733,5 @@ func HEIFToJPEG(fr io.Reader, maxSize *Dimensions) ([]byte, error) {
 	if debug {
 		log.Printf("internal/images: ran imagemagick heic conversion in %v", time.Since(t0))
 	}
-	return ioutil.ReadFile(outFile)
+	return os.ReadFile(outFile)
 }

--- a/internal/magic/magic_test.go
+++ b/internal/magic/magic_test.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"errors"
 	"io"
-	"io/ioutil"
+	"os"
 	"os/exec"
 	"strings"
 	"testing"
@@ -72,7 +72,7 @@ func TestMagic(t *testing.T) {
 		var err error
 		data := []byte(tt.data)
 		if tt.fileName != "" {
-			data, err = ioutil.ReadFile("testdata/" + tt.fileName)
+			data, err = os.ReadFile("testdata/" + tt.fileName)
 			if err != nil {
 				t.Fatalf("Error reading %s: %v", tt.fileName,
 					err)
@@ -136,7 +136,7 @@ func TestMIMETypeFromReader(t *testing.T) {
 	if want := "text/html"; mime != want {
 		t.Errorf("mime = %q; want %q", mime, want)
 	}
-	slurp, err := ioutil.ReadAll(r)
+	slurp, err := io.ReadAll(r)
 	if string(slurp) != "<html>foobar" {
 		t.Errorf("read = %q; want %q", slurp, content)
 	}

--- a/internal/netutil/ident_test.go
+++ b/internal/netutil/ident_test.go
@@ -18,7 +18,7 @@ package netutil
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -115,7 +115,7 @@ func TestHTTPAuth(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/osutil/paths_test.go
+++ b/internal/osutil/paths_test.go
@@ -18,7 +18,7 @@ package osutil
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 	"path/filepath"
@@ -140,7 +140,7 @@ func TestCamPkConfigMigration(t *testing.T) {
 		configDirNamedTestHook = nil
 		log.SetOutput(os.Stderr)
 	}()
-	log.SetOutput(ioutil.Discard)
+	log.SetOutput(io.Discard)
 
 	td := t.TempDir()
 
@@ -185,7 +185,7 @@ func TestCamPkConfigMigration(t *testing.T) {
 	if err := os.MkdirAll(filepath.Join(oldDir, "blobs"), 0755); err != nil {
 		t.Fatal(err)
 	}
-	if err := ioutil.WriteFile(filepath.Join(oldDir, "blobs/x.dat"), []byte("hi"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(oldDir, "blobs/x.dat"), []byte("hi"), 0644); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/video/thumbnail/handler_test.go
+++ b/internal/video/thumbnail/handler_test.go
@@ -18,7 +18,7 @@ package thumbnail
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -66,7 +66,7 @@ func TestHandlerRightRef(t *testing.T) {
 	if resp.StatusCode != 200 {
 		t.Fatalf("expected 200 status: %v", resp)
 	}
-	content, err := ioutil.ReadAll(resp.Body)
+	content, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/video/thumbnail/service.go
+++ b/internal/video/thumbnail/service.go
@@ -32,7 +32,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"time"
@@ -127,7 +126,7 @@ func (s *Service) Generate(videoRef blob.Ref, w io.Writer, src blob.Fetcher) err
 	}
 	defer cmd.Process.Kill()
 	go func() {
-		out, err := ioutil.ReadAll(cmdErrOut)
+		out, err := io.ReadAll(cmdErrOut)
 		if err != nil {
 			cmdErrc <- err
 			return

--- a/internal/video/thumbnail/service_test.go
+++ b/internal/video/thumbnail/service_test.go
@@ -19,7 +19,7 @@ package thumbnail
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"io"
 	"net/url"
 	"os"
 	"os/exec"
@@ -58,11 +58,11 @@ func TestStorage(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	data, err := ioutil.ReadAll(inFile)
+	data, err := io.ReadAll(inFile)
 	if err != nil {
 		t.Fatal(err)
 	}
-	bd, err := ioutil.ReadAll(fr)
+	bd, err := io.ReadAll(fr)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -77,7 +77,7 @@ func TestMakeThumbnail(t *testing.T) {
 	}
 
 	store, ref := storageAndBlobRef(t)
-	tmpFile, _ := ioutil.TempFile(t.TempDir(), "camlitest")
+	tmpFile, _ := os.CreateTemp(t.TempDir(), "camlitest")
 	defer tmpFile.Close()
 
 	service := NewService(DefaultThumbnailer, 30*time.Second, 5)
@@ -100,7 +100,7 @@ func TestMakeThumbnailWithZeroMaxProcsAndTimeout(t *testing.T) {
 	}
 
 	store, ref := storageAndBlobRef(t)
-	tmpFile, _ := ioutil.TempFile(t.TempDir(), "camlitest")
+	tmpFile, _ := os.CreateTemp(t.TempDir(), "camlitest")
 	defer tmpFile.Close()
 
 	service := NewService(DefaultThumbnailer, 0, 0)
@@ -122,7 +122,7 @@ func TestMakeThumbnailFailure(t *testing.T) {
 
 	store, ref := storageAndBlobRef(t)
 	service := NewService(failingThumbnailer{}, 2*time.Second, 5)
-	err := service.Generate(ref, ioutil.Discard, store)
+	err := service.Generate(ref, io.Discard, store)
 
 	if err == nil {
 		t.Error("expected to fail.")
@@ -145,7 +145,7 @@ func TestThumbnailGenerateTimeout(t *testing.T) {
 
 	store, ref := storageAndBlobRef(t)
 	service := NewService(sleepyThumbnailer{}, time.Duration(time.Millisecond), 5)
-	err := service.Generate(ref, ioutil.Discard, store)
+	err := service.Generate(ref, io.Discard, store)
 
 	if err != errTimeout {
 		t.Errorf("expected to timeout: %v", err)

--- a/make.go
+++ b/make.go
@@ -35,7 +35,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
@@ -333,11 +332,11 @@ func genJS(pkg, output string) error {
 		// output exists and is already up to date, nothing to do
 		return nil
 	}
-	data, err := ioutil.ReadFile(jsout)
+	data, err := os.ReadFile(jsout)
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(output, data, 0600)
+	return os.WriteFile(output, data, 0600)
 }
 
 func runGopherJS(pkg string) error {
@@ -395,7 +394,7 @@ func fetchJS(jsURL, jsOnDisk string) error {
 		return err
 	}
 	defer resp.Body.Close()
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}
@@ -559,7 +558,7 @@ func buildBin(pkg string) error {
 
 // getVersion returns the version of Perkeep found in a VERSION file at the root.
 func getVersion() string {
-	slurp, err := ioutil.ReadFile(filepath.Join(pkRoot, "VERSION"))
+	slurp, err := os.ReadFile(filepath.Join(pkRoot, "VERSION"))
 	v := strings.TrimSpace(string(slurp))
 	if err != nil && !os.IsNotExist(err) {
 		log.Fatal(err)
@@ -782,7 +781,7 @@ func embedClosure(closureDir, embedFile string) error {
 	}
 	w := zip.NewWriter(zipdest)
 	for _, elt := range files {
-		b, err := ioutil.ReadFile(elt.path)
+		b, err := os.ReadFile(elt.path)
 		if err != nil {
 			return err
 		}
@@ -822,11 +821,11 @@ func writeFileIfDifferent(filename string, contents []byte) error {
 	if err == nil && fi.Size() == int64(len(contents)) && contentsEqual(filename, contents) {
 		return nil
 	}
-	return ioutil.WriteFile(filename, contents, 0644)
+	return os.WriteFile(filename, contents, 0644)
 }
 
 func contentsEqual(filename string, contents []byte) bool {
-	got, err := ioutil.ReadFile(filename)
+	got, err := os.ReadFile(filename)
 	if os.IsNotExist(err) {
 		return false
 	}

--- a/misc/docker/dock.go
+++ b/misc/docker/dock.go
@@ -24,7 +24,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -124,9 +123,9 @@ func genPerkeep(ctxDir string) {
 
 func copyFinalDockerfile(ctxDir string) {
 	// Copy Dockerfile into the temp dir.
-	serverDockerFile, err := ioutil.ReadFile(filepath.Join(dockDir, "server", "Dockerfile"))
+	serverDockerFile, err := os.ReadFile(filepath.Join(dockDir, "server", "Dockerfile"))
 	check(err)
-	check(ioutil.WriteFile(filepath.Join(ctxDir, "Dockerfile"), serverDockerFile, 0644))
+	check(os.WriteFile(filepath.Join(ctxDir, "Dockerfile"), serverDockerFile, 0644))
 }
 
 func genDjpeg(ctxDir string) {
@@ -306,12 +305,12 @@ func main() {
 	buildDockerImage("go", goDockerImage)
 	// ctxDir is where we run "docker build" to produce the final
 	// "FROM scratch" Docker image.
-	ctxDir, err := ioutil.TempDir("", "pk-build_docker_image")
+	ctxDir, err := os.MkdirTemp("", "pk-build_docker_image")
 	if err != nil {
 		log.Fatal(err)
 	}
 	// Docker Desktop for Mac by default shares /private, but does not share /var.
-	// ioutil.TempDir gives us something in /var/folders, but apparently the same
+	// os.MkdirTemp gives us something in /var/folders, but apparently the same
 	// location prefixed with /private is equivalent, so it all works out if we use
 	// everywhere the path prefixed with /private.
 	if runtime.GOOS == "darwin" {
@@ -353,7 +352,7 @@ func ProjectTokenSource(proj string, scopes ...string) (oauth2.TokenSource, erro
 	// option, for environments without stdin/stdout available to the user.
 	// We'll figure it out as needed.
 	fileName := filepath.Join(homedir(), "keys", proj+".key.json")
-	jsonConf, err := ioutil.ReadFile(fileName)
+	jsonConf, err := os.ReadFile(fileName)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, fmt.Errorf("Missing JSON key configuration. Download the Service Account JSON key from https://console.developers.google.com/project/%s/apiui/credential and place it at %s", proj, fileName)

--- a/misc/docker/server/build-perkeep-server.go
+++ b/misc/docker/server/build-perkeep-server.go
@@ -29,7 +29,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
@@ -88,7 +87,7 @@ func getCamliSrc() {
 	// we insert the version in the VERSION file, so make.go does no need git
 	// in the container to detect the Perkeep version.
 	check(os.Chdir("/gopath/src/perkeep.org"))
-	check(ioutil.WriteFile("VERSION", []byte(rev()), 0777))
+	check(os.WriteFile("VERSION", []byte(rev()), 0777))
 }
 
 func mirrorCamliSrc(srcDir string) {

--- a/misc/release/make-release.go
+++ b/misc/release/make-release.go
@@ -33,7 +33,6 @@ import (
 	"fmt"
 	"html/template"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -112,7 +111,7 @@ func main() {
 	}
 	releaseDir = filepath.Join(pkDir, "misc", "release")
 
-	workDir, err = ioutil.TempDir("", "pk-build_release")
+	workDir, err = os.MkdirTemp("", "pk-build_release")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -327,7 +326,7 @@ func packBinaries(osType string) string {
 			if !toPack(name) {
 				continue
 			}
-			b, err := ioutil.ReadFile(path.Join(binDir, name))
+			b, err := os.ReadFile(path.Join(binDir, name))
 			check(err)
 			f, err := w.Create(name)
 			check(err)
@@ -675,7 +674,7 @@ func genReleasePage(releaseData *ReleaseData) error {
 		return err
 	}
 	releaseDocPage := filepath.Join(releaseDocDir, "release.html")
-	if err := ioutil.WriteFile(releaseDocPage, buf.Bytes(), 0700); err != nil {
+	if err := os.WriteFile(releaseDocPage, buf.Bytes(), 0700); err != nil {
 		return fmt.Errorf("could not write template to file %v: %v", releaseDocPage, err)
 	}
 	return nil
@@ -914,7 +913,7 @@ func ProjectTokenSource(proj string, scopes ...string) (oauth2.TokenSource, erro
 	// option, for environments without stdin/stdout available to the user.
 	// We'll figure it out as needed.
 	fileName := filepath.Join(homedir(), "keys", proj+".key.json")
-	jsonConf, err := ioutil.ReadFile(fileName)
+	jsonConf, err := os.ReadFile(fileName)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, fmt.Errorf("Missing JSON key configuration. Download the Service Account JSON key from https://console.developers.google.com/project/%s/apiui/credential and place it at %s", proj, fileName)

--- a/misc/release/zip-source.go
+++ b/misc/release/zip-source.go
@@ -29,7 +29,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
@@ -276,7 +275,7 @@ func pack() {
 		if fi.IsDir() {
 			return nil
 		}
-		b, err := ioutil.ReadFile(filePath)
+		b, err := os.ReadFile(filePath)
 		if err != nil {
 			return err
 		}

--- a/pkg/blob/blob.go
+++ b/pkg/blob/blob.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"sync/atomic"
 	"unicode/utf8"
 
@@ -139,7 +138,7 @@ func FromReader(ctx context.Context, br Ref, r io.Reader, size uint32) (*Blob, e
 	if n, err := io.ReadFull(r, buf); err != nil {
 		return nil, fmt.Errorf("blob: after reading %d bytes of %v: %v", n, br, err)
 	}
-	n, _ := io.CopyN(ioutil.Discard, r, 1)
+	n, _ := io.CopyN(io.Discard, r, 1)
 	if n > 0 {
 		return nil, fmt.Errorf("blob: %v had more than reported %d bytes", br, size)
 	}

--- a/pkg/blobserver/archiver/archiver_test.go
+++ b/pkg/blobserver/archiver/archiver_test.go
@@ -23,7 +23,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"reflect"
 	"strings"
@@ -193,7 +192,7 @@ func foreachZipEntry(zipData []byte, fn func(blob.Ref, []byte)) error {
 		if err != nil {
 			return err
 		}
-		all, err := ioutil.ReadAll(rc)
+		all, err := io.ReadAll(rc)
 		rc.Close()
 		if err != nil {
 			return err

--- a/pkg/blobserver/blobpacked/blobpacked_test.go
+++ b/pkg/blobserver/blobpacked/blobpacked_test.go
@@ -24,7 +24,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"runtime"
 	"sort"
@@ -638,7 +637,7 @@ func testPack(t *testing.T,
 		if err != nil {
 			t.Fatal(err)
 		}
-		zipBytes, err := ioutil.ReadAll(rc)
+		zipBytes, err := io.ReadAll(rc)
 		rc.Close()
 		if err != nil {
 			t.Fatalf("Error slurping %s: %v", zipRef, err)
@@ -666,7 +665,7 @@ func testPack(t *testing.T,
 		if err != nil {
 			t.Fatalf("Error opening manifest JSON: %v", err)
 		}
-		maniJSON, err := ioutil.ReadAll(mfr)
+		maniJSON, err := io.ReadAll(mfr)
 		if err != nil {
 			t.Fatalf("Error reading manifest JSON: %v", err)
 		}
@@ -1098,7 +1097,7 @@ func slurpBlob(t *testing.T, sto blob.Fetcher, br blob.Ref) []byte {
 		t.Fatal(err)
 	}
 	defer rc.Close()
-	slurp, err := ioutil.ReadAll(rc)
+	slurp, err := io.ReadAll(rc)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/blobserver/blobpacked/stream.go
+++ b/pkg/blobserver/blobpacked/stream.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"strconv"
 	"strings"
 
@@ -135,7 +135,7 @@ func slurpSizedRef(ctx context.Context, f blob.Fetcher, sb blob.SizedRef) ([]byt
 	if size != sb.Size {
 		return nil, fmt.Errorf("blobpacked fetch of %v reported %d bytes; expected %d", sb.Ref, size, sb.Size)
 	}
-	slurp, err := ioutil.ReadAll(rc)
+	slurp, err := io.ReadAll(rc)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/blobserver/blobpacked/subfetch.go
+++ b/pkg/blobserver/blobpacked/subfetch.go
@@ -19,7 +19,6 @@ package blobpacked
 import (
 	"context"
 	"io"
-	"io/ioutil"
 
 	"perkeep.org/pkg/blob"
 )
@@ -62,7 +61,7 @@ func (s *storage) SubFetch(ctx context.Context, ref blob.Ref, offset, length int
 		return nil, err
 	}
 	if offset != 0 {
-		if _, err = io.CopyN(ioutil.Discard, rc, offset); err != nil {
+		if _, err = io.CopyN(io.Discard, rc, offset); err != nil {
 			rc.Close()
 			return nil, err
 		}

--- a/pkg/blobserver/diskpacked/diskpacked.go
+++ b/pkg/blobserver/diskpacked/diskpacked.go
@@ -39,7 +39,6 @@ import (
 	"expvar"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -599,7 +598,7 @@ func (s *storage) StreamBlobs(ctx context.Context, dest chan<- blobserver.BlobAn
 		offset += int64(consumed)
 		if deletedBlobRef.Match(digest) {
 			// Skip over deletion padding
-			if _, err := io.CopyN(ioutil.Discard, r, int64(size)); err != nil {
+			if _, err := io.CopyN(io.Discard, r, int64(size)); err != nil {
 				return err
 			}
 			offset += int64(size)

--- a/pkg/blobserver/diskpacked/diskpacked_test.go
+++ b/pkg/blobserver/diskpacked/diskpacked_test.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 	"expvar"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -53,7 +52,7 @@ func newTempDiskpackedMemory(t *testing.T) (sto blobserver.Storage, cleanup func
 
 func newTempDiskpackedWithIndex(t *testing.T, indexConf jsonconfig.Obj) (sto blobserver.Storage, cleanup func()) {
 	restoreLogging := test.TLog(t)
-	dir, err := ioutil.TempDir("", "diskpacked-test")
+	dir, err := os.MkdirTemp("", "diskpacked-test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -350,7 +349,7 @@ func TestWriteError(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("skipping symlink test on Windows")
 	}
-	dir, err := ioutil.TempDir("", "diskpacked-test")
+	dir, err := os.MkdirTemp("", "diskpacked-test")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/blobserver/diskpacked/reindex.go
+++ b/pkg/blobserver/diskpacked/reindex.go
@@ -23,7 +23,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"strconv"
@@ -240,7 +239,7 @@ func (s *storage) walkPack(verbose bool, packID int,
 			return errAt("", "cannot seek +"+strconv.FormatUint(size64, 10)+" bytes")
 		}
 		// drain the buffer after the underlying reader Seeks
-		_, _ = io.CopyN(ioutil.Discard, br, int64(br.Buffered()))
+		_, _ = io.CopyN(io.Discard, br, int64(br.Buffered()))
 	}
 	return nil
 }

--- a/pkg/blobserver/encrypt/encrypt.go
+++ b/pkg/blobserver/encrypt/encrypt.go
@@ -52,7 +52,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"time"
@@ -236,7 +235,7 @@ func (s *storage) Fetch(ctx context.Context, plainBR blob.Ref) (io.ReadCloser, u
 		return nil, 0, fmt.Errorf("encrypt: encrypted blob %s failed validation: %s", encBR, err)
 	}
 
-	return ioutil.NopCloser(plainBytes), plainSize, nil
+	return io.NopCloser(plainBytes), plainSize, nil
 }
 
 func (s *storage) EnumerateBlobs(ctx context.Context, dest chan<- blob.SizedRef, after string, limit int) error {

--- a/pkg/blobserver/encrypt/encrypt_test.go
+++ b/pkg/blobserver/encrypt/encrypt_test.go
@@ -29,7 +29,7 @@ $ ./dev-camtool sync --src=http://localhost:3179/enc/ --dest=stdout
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"runtime"
 	"strings"
@@ -62,7 +62,7 @@ func (ts *testStorage) fetchOrErrorString(br blob.Ref) string {
 	var slurp []byte
 	if err == nil {
 		defer rc.Close()
-		slurp, err = ioutil.ReadAll(rc)
+		slurp, err = io.ReadAll(rc)
 	}
 	if err != nil {
 		return fmt.Sprintf("Error: %v", err)
@@ -228,7 +228,7 @@ func TestNewFromConfig(t *testing.T) {
 	ld := test.NewLoader()
 
 	// Using key file
-	tmpKeyFile, _ := ioutil.TempFile(t.TempDir(), "camlitest")
+	tmpKeyFile, _ := os.CreateTemp(t.TempDir(), "camlitest")
 	defer os.Remove((tmpKeyFile.Name()))
 	defer tmpKeyFile.Close()
 	tmpKeyFile.WriteString(testIdentity.String())

--- a/pkg/blobserver/encrypt/meta.go
+++ b/pkg/blobserver/encrypt/meta.go
@@ -23,7 +23,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"sort"
@@ -294,7 +293,7 @@ func (s *storage) readAllMetaBlobs() error {
 					return
 				}
 				defer rc.Close()
-				all, err := ioutil.ReadAll(rc)
+				all, err := io.ReadAll(rc)
 				if err != nil {
 					metac <- encMB{sb.Ref, nil, fmt.Errorf("read failed: %v", err)}
 					return

--- a/pkg/blobserver/files/enumerate_test.go
+++ b/pkg/blobserver/files/enumerate_test.go
@@ -19,7 +19,6 @@ package files_test
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"sort"
 	"sync"
@@ -146,7 +145,7 @@ func TestEnumerateIsSorted(t *testing.T) {
 	if err := os.MkdirAll(fakeDir, 0755); err != nil {
 		t.Fatalf("error creating fakedir: %v", err)
 	}
-	if err := ioutil.WriteFile(
+	if err := os.WriteFile(
 		fakeDir+"/sha1-1f07105465650aa243cfc1b1bbb1c68ea95c6812.dat",
 		[]byte("fake file"),
 		0644,
@@ -159,7 +158,7 @@ func TestEnumerateIsSorted(t *testing.T) {
 	if err := os.MkdirAll(fakeDir, 0755); err != nil {
 		t.Fatalf("error creating cachedir: %v", err)
 	}
-	if err := ioutil.WriteFile(
+	if err := os.WriteFile(
 		fakeDir+"/sha1-1f07105465650aa243cfc1b1bbb1c68ea95c6812.dat",
 		[]byte("fake file"),
 		0644,

--- a/pkg/blobserver/files/files.go
+++ b/pkg/blobserver/files/files.go
@@ -52,7 +52,7 @@ type VFS interface {
 	// Rename is a POSIX-style rename, overwriting newname if it exists.
 	Rename(oldname, newname string) error
 
-	// TempFile should behave like io/ioutil.TempFile.
+	// TempFile should behave like os.CreateTemp
 	TempFile(dir, prefix string) (WritableFile, error)
 
 	ReadDirNames(dir string) ([]string, error)

--- a/pkg/blobserver/files/osfs.go
+++ b/pkg/blobserver/files/osfs.go
@@ -17,7 +17,6 @@ limitations under the License.
 package files
 
 import (
-	"io/ioutil"
 	"os"
 )
 
@@ -46,7 +45,7 @@ func (osFS) Rename(oldname, newname string) error {
 }
 
 func (osFS) TempFile(dir, prefix string) (WritableFile, error) {
-	f, err := ioutil.TempFile(dir, prefix)
+	f, err := os.CreateTemp(dir, prefix)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/blobserver/gethandler/get_test.go
+++ b/pkg/blobserver/gethandler/get_test.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"errors"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -132,7 +131,7 @@ func (f fetcher) Fetch(ctx context.Context, br blob.Ref) (rc io.ReadCloser, size
 	if rc, ok := f.r.(io.ReadCloser); ok {
 		return rc, uint32(f.size), nil
 	}
-	return ioutil.NopCloser(f.r), uint32(f.size), nil
+	return io.NopCloser(f.r), uint32(f.size), nil
 }
 
 type altWriterRecorder struct {

--- a/pkg/blobserver/google/cloudstorage/cloudstorage_test.go
+++ b/pkg/blobserver/google/cloudstorage/cloudstorage_test.go
@@ -21,8 +21,8 @@ import (
 	"encoding/json"
 	"flag"
 	"io"
-	"io/ioutil"
 	"log"
+	"os"
 	"path"
 	"strings"
 	"testing"
@@ -74,7 +74,7 @@ func testStorage(t *testing.T, bucketDir string) {
 	}
 	var refreshToken string
 	if *configFile != "" {
-		data, err := ioutil.ReadFile(*configFile)
+		data, err := os.ReadFile(*configFile)
 		if err != nil {
 			t.Fatalf("Error reading config file %v: %v", *configFile, err)
 		}
@@ -191,7 +191,7 @@ func testStorage(t *testing.T, bucketDir string) {
 							if err != nil {
 								t.Fatalf("could not find object %s after tests: %v", key, err)
 							}
-							if _, err := io.Copy(ioutil.Discard, rc); err != nil {
+							if _, err := io.Copy(io.Discard, rc); err != nil {
 								t.Fatalf("could not find object %s after tests: %v", key, err)
 							}
 							if err := stor.client.Bucket(stor.bucket).Object(key).Delete(ctx); err != nil {

--- a/pkg/blobserver/google/drive/drive_test.go
+++ b/pkg/blobserver/google/drive/drive_test.go
@@ -19,8 +19,8 @@ package drive
 import (
 	"encoding/json"
 	"flag"
-	"io/ioutil"
 	"log"
+	"os"
 	"testing"
 
 	"go4.org/jsonconfig"
@@ -58,7 +58,7 @@ func TestStorage(t *testing.T) {
 	}
 	var refreshToken string
 	if *configFile != "" {
-		data, err := ioutil.ReadFile(*configFile)
+		data, err := os.ReadFile(*configFile)
 		if err != nil {
 			t.Fatalf("Error reading config file %v: %v", *configFile, err)
 		}

--- a/pkg/blobserver/local/generation.go
+++ b/pkg/blobserver/local/generation.go
@@ -25,7 +25,6 @@ import (
 	"crypto/rand"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -59,7 +58,7 @@ func (g Generationer) StorageGeneration() (initTime time.Time, random string, er
 		return
 	}
 	defer f.Close()
-	bs, err := ioutil.ReadAll(f)
+	bs, err := io.ReadAll(f)
 	if err != nil {
 		return
 	}
@@ -101,5 +100,5 @@ delete this file so clients can safely re-upload them.
 
 `)
 
-	return ioutil.WriteFile(g.generationFile(), buf.Bytes(), 0644)
+	return os.WriteFile(g.generationFile(), buf.Bytes(), 0644)
 }

--- a/pkg/blobserver/localdisk/localdisk.go
+++ b/pkg/blobserver/localdisk/localdisk.go
@@ -32,7 +32,6 @@ package localdisk // import "perkeep.org/pkg/blobserver/localdisk"
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -161,7 +160,7 @@ func init() {
 //
 // TODO: move this into the files package too?
 func (ds *DiskStorage) checkFS() (ret error) {
-	tempdir, err := ioutil.TempDir(ds.root, "")
+	tempdir, err := os.MkdirTemp(ds.root, "")
 	if err != nil {
 		return fmt.Errorf("localdisk check: unable to create tempdir in %s, err=%v", ds.root, err)
 	}
@@ -180,12 +179,12 @@ func (ds *DiskStorage) checkFS() (ret error) {
 	tempfile := filepath.Join(tempdir, "FILE.tmp")
 	filename := filepath.Join(tempdir, "FILE")
 	data := []byte("perkeep rocks")
-	err = ioutil.WriteFile(tempfile, data, 0644)
+	err = os.WriteFile(tempfile, data, 0644)
 	if err != nil {
 		return fmt.Errorf("localdisk check: unable to write into %s, err=%v", ds.root, err)
 	}
 
-	out, err := ioutil.ReadFile(tempfile)
+	out, err := os.ReadFile(tempfile)
 	if err != nil {
 		return fmt.Errorf("localdisk check: unable to read from %s, err=%v", tempfile, err)
 	}

--- a/pkg/blobserver/memory/mem.go
+++ b/pkg/blobserver/memory/mem.go
@@ -23,7 +23,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"sort"
 	"sync"
@@ -138,7 +137,7 @@ func (s *Storage) ReceiveBlob(ctx context.Context, br blob.Ref, source io.Reader
 	if h == nil {
 		return sb, fmt.Errorf("Unsupported blobref hash for %s", br)
 	}
-	all, err := ioutil.ReadAll(io.TeeReader(source, h))
+	all, err := io.ReadAll(io.TeeReader(source, h))
 	if err != nil {
 		return sb, err
 	}

--- a/pkg/blobserver/mongo/fetch.go
+++ b/pkg/blobserver/mongo/fetch.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 
 	"gopkg.in/mgo.v2/bson"
 	"perkeep.org/pkg/blob"
@@ -36,5 +35,5 @@ func (m *mongoStorage) Fetch(ctx context.Context, ref blob.Ref) (io.ReadCloser, 
 	if len(b.Blob) != int(b.Size) {
 		return nil, 0, fmt.Errorf("blob data size %d doesn't match meta size %d", len(b.Blob), b.Size)
 	}
-	return ioutil.NopCloser(bytes.NewReader(b.Blob)), b.Size, nil
+	return io.NopCloser(bytes.NewReader(b.Blob)), b.Size, nil
 }

--- a/pkg/blobserver/mongo/receive.go
+++ b/pkg/blobserver/mongo/receive.go
@@ -19,7 +19,6 @@ package mongo
 import (
 	"context"
 	"io"
-	"io/ioutil"
 
 	"perkeep.org/pkg/blob"
 
@@ -33,7 +32,7 @@ const (
 )
 
 func (m *mongoStorage) ReceiveBlob(ctx context.Context, ref blob.Ref, source io.Reader) (blob.SizedRef, error) {
-	blobData, err := ioutil.ReadAll(source)
+	blobData, err := io.ReadAll(source)
 	if err != nil {
 		return blob.SizedRef{}, err
 	}

--- a/pkg/blobserver/proxycache/proxycache.go
+++ b/pkg/blobserver/proxycache/proxycache.go
@@ -38,7 +38,6 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"sync"
@@ -163,7 +162,7 @@ func (sto *Storage) Fetch(ctx context.Context, b blob.Ref) (rc io.ReadCloser, si
 	if err != nil {
 		return
 	}
-	all, err := ioutil.ReadAll(rc)
+	all, err := io.ReadAll(rc)
 	if err != nil {
 		return
 	}
@@ -172,7 +171,7 @@ func (sto *Storage) Fetch(ctx context.Context, b blob.Ref) (rc io.ReadCloser, si
 	} else {
 		sto.touch(blob.SizedRef{Ref: b, Size: size})
 	}
-	return ioutil.NopCloser(bytes.NewReader(all)), size, nil
+	return io.NopCloser(bytes.NewReader(all)), size, nil
 }
 
 func (sto *Storage) SubFetch(ctx context.Context, ref blob.Ref, offset, length int64) (io.ReadCloser, error) {

--- a/pkg/blobserver/s3/s3_preflight.go
+++ b/pkg/blobserver/s3/s3_preflight.go
@@ -22,7 +22,6 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/url"
 	"regexp"
@@ -141,7 +140,7 @@ func determineEndpoint(ctx context.Context, svc s3iface.S3API, endpoint, bucket,
 			return
 		}
 		determinedEndpoint = epErr.Endpoint
-		r.HTTPResponse.Body = ioutil.NopCloser(&b)
+		r.HTTPResponse.Body = io.NopCloser(&b)
 	})
 	err := req.Send()
 	if determinedEndpoint == "" && err != nil {

--- a/pkg/blobserver/s3/s3_test.go
+++ b/pkg/blobserver/s3/s3_test.go
@@ -19,7 +19,7 @@ package s3
 import (
 	"context"
 	"flag"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"os"
@@ -208,7 +208,7 @@ func TestS3EndpointRedirect(t *testing.T) {
 					Header: http.Header(map[string][]string{
 						"X-Amz-Bucket-Region": []string{"us-east-1"},
 					}),
-					Body: ioutil.NopCloser(strings.NewReader(`<?xml version="1.0" encoding="UTF-8"?>
+					Body: io.NopCloser(strings.NewReader(`<?xml version="1.0" encoding="UTF-8"?>
 <LocationConstraint xmlns="http://s3.amazonaws.com/doc/2006-03-01/">us-west-1</LocationConstraint>`)),
 				}
 			},
@@ -222,7 +222,7 @@ func TestS3EndpointRedirect(t *testing.T) {
 					Header: http.Header(map[string][]string{
 						"X-Amz-Bucket-Region": []string{"us-east-1"},
 					}),
-					Body: ioutil.NopCloser(strings.NewReader(`<?xml version="1.0" encoding="UTF-8"?>
+					Body: io.NopCloser(strings.NewReader(`<?xml version="1.0" encoding="UTF-8"?>
 <Error><Code>PermanentRedirect</Code><Message>The bucket you are attempting to access must be addressed using the specified endpoint. Please send all future requests to this endpoint.</Message><Bucket>mock_bucket</Bucket><Endpoint>mock_bucket.s3.amazonaws.com</Endpoint><RequestId>123</RequestId><HostId>abc</HostId></Error>`)),
 				}
 			},
@@ -233,7 +233,7 @@ func TestS3EndpointRedirect(t *testing.T) {
 				return &http.Response{
 					Status:     "200 OK",
 					StatusCode: 200,
-					Body: ioutil.NopCloser(strings.NewReader(`
+					Body: io.NopCloser(strings.NewReader(`
 <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>mock_bucket</Name><Prefix></Prefix><MaxKeys>1</MaxKeys><Marker></Marker><IsTruncated>false</IsTruncated><Contents></Contents></ListBucketResult>
 					`)),
 				}
@@ -272,7 +272,7 @@ func TestNonS3Endpoints(t *testing.T) {
 					return &http.Response{
 						Status:     "200 OK",
 						StatusCode: 200,
-						Body: ioutil.NopCloser(strings.NewReader(`
+						Body: io.NopCloser(strings.NewReader(`
 		<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>mock_bucket</Name><Prefix></Prefix><MaxKeys>1</MaxKeys><Marker></Marker><IsTruncated>false</IsTruncated><Contents></Contents></ListBucketResult>
 							`)),
 					}

--- a/pkg/blobserver/sftp/sftp_test.go
+++ b/pkg/blobserver/sftp/sftp_test.go
@@ -19,7 +19,6 @@ package sftp
 import (
 	"encoding/json"
 	"flag"
-	"io/ioutil"
 	"net"
 	"os"
 	"path"
@@ -73,7 +72,7 @@ func TestStorage_Memory(t *testing.T) {
 }
 
 func TestStorage_TempDir(t *testing.T) {
-	td, err := ioutil.TempDir("", "sftptest")
+	td, err := os.MkdirTemp("", "sftptest")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -92,7 +91,7 @@ func TestStorage_Manual(t *testing.T) {
 	if sftpTestAuthFile == "" {
 		t.Skipf("skipping integration test when %s not set to path to JSON file of config for testing", testEnvKey)
 	}
-	jconf, err := ioutil.ReadFile(sftpTestAuthFile)
+	jconf, err := os.ReadFile(sftpTestAuthFile)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/blobserver/stats/statreceiver.go
+++ b/pkg/blobserver/stats/statreceiver.go
@@ -21,7 +21,6 @@ package stats // import "perkeep.org/pkg/blobserver/stats"
 import (
 	"context"
 	"io"
-	"io/ioutil"
 	"sort"
 	"sync"
 
@@ -68,7 +67,7 @@ func (sr *Receiver) SumBlobSize() int64 {
 }
 
 func (sr *Receiver) ReceiveBlob(ctx context.Context, br blob.Ref, source io.Reader) (sb blob.SizedRef, err error) {
-	n, err := io.Copy(ioutil.Discard, source)
+	n, err := io.Copy(io.Discard, source)
 	if err != nil {
 		return
 	}

--- a/pkg/blobserver/storagetest/storagetest.go
+++ b/pkg/blobserver/storagetest/storagetest.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"reflect"
 	"sort"
 	"strconv"
@@ -223,7 +222,7 @@ func (r *run) testSubFetcher() {
 		if r == nil {
 			t.Fatal("SubFetch returned nil, nil")
 		}
-		all, err := ioutil.ReadAll(r)
+		all, err := io.ReadAll(r)
 		r.Close()
 		if err != nil && !tt.errok {
 			t.Errorf("Unexpected error reading SubFetch region %+v: %v", tt, err)

--- a/pkg/cacher/cacher.go
+++ b/pkg/cacher/cacher.go
@@ -20,7 +20,6 @@ package cacher // import "perkeep.org/pkg/cacher"
 import (
 	"context"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -114,7 +113,7 @@ func NewDiskCache(fetcher blob.Fetcher) (*DiskCache, error) {
 	if !osutil.DirExists(cacheDir) {
 		if err := os.Mkdir(cacheDir, 0700); err != nil {
 			log.Printf("Warning: failed to make %s: %v; using tempdir instead", cacheDir, err)
-			cacheDir, err = ioutil.TempDir("", "camlicache")
+			cacheDir, err = os.MkdirTemp("", "camlicache")
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/client/android/androidx.go
+++ b/pkg/client/android/androidx.go
@@ -26,7 +26,6 @@ import (
 	"crypto/x509"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net"
 	"net/http"
@@ -276,7 +275,7 @@ func TLSConfig() (*tls.Config, error) {
 	defer f.Close()
 	names, _ := f.Readdirnames(-1)
 	for _, name := range names {
-		pem, err := ioutil.ReadFile(filepath.Join(certDir, name))
+		pem, err := os.ReadFile(filepath.Join(certDir, name))
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -25,7 +25,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net"
 	"net/http"
@@ -812,7 +811,7 @@ func (c *Client) QueryRaw(ctx context.Context, req *search.SearchQuery) ([]byte,
 		return nil, err
 	}
 	defer hres.Body.Close()
-	return ioutil.ReadAll(hres.Body)
+	return io.ReadAll(hres.Body)
 }
 
 // SearchExistingFileSchema does a search query looking for an
@@ -848,7 +847,7 @@ func (c *Client) SearchExistingFileSchema(ctx context.Context, wholeRef ...blob.
 		return blob.Ref{}, err
 	}
 	if res.StatusCode != 200 {
-		body, _ := ioutil.ReadAll(io.LimitReader(res.Body, 1<<20))
+		body, _ := io.ReadAll(io.LimitReader(res.Body, 1<<20))
 		res.Body.Close()
 		return blob.Ref{}, fmt.Errorf("client: got status code %d from URL %s; body %s", res.StatusCode, url, body)
 	}
@@ -901,7 +900,7 @@ func (c *Client) versionMismatch(ctx context.Context) (bool, error) {
 		return false, err
 	}
 	if res.StatusCode != 200 {
-		body, _ := ioutil.ReadAll(io.LimitReader(res.Body, 1<<20))
+		body, _ := io.ReadAll(io.LimitReader(res.Body, 1<<20))
 		res.Body.Close()
 		return false, fmt.Errorf("got status code %d from URL %s; body %s", res.StatusCode, url, body)
 	}
@@ -1019,7 +1018,7 @@ func (c *Client) DiscoveryDoc(ctx context.Context) (io.Reader, error) {
 	}
 	defer res.Body.Close()
 	const maxSize = 1 << 20
-	all, err := ioutil.ReadAll(io.LimitReader(res.Body, maxSize+1))
+	all, err := io.ReadAll(io.LimitReader(res.Body, maxSize+1))
 	if err != nil {
 		return nil, err
 	}
@@ -1191,7 +1190,7 @@ func (c *Client) Sign(ctx context.Context, server string, r io.Reader) (signed [
 		return nil, err
 	}
 	defer resp.Body.Close()
-	return ioutil.ReadAll(resp.Body)
+	return io.ReadAll(resp.Body)
 }
 
 func (c *Client) post(ctx context.Context, url string, bodyType string, body io.Reader) (*http.Response, error) {

--- a/pkg/client/stat_test.go
+++ b/pkg/client/stat_test.go
@@ -17,7 +17,7 @@ limitations under the License.
 package client
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"reflect"
 	"strings"
@@ -43,7 +43,7 @@ var response = `{
 
 func TestParseStatResponse(t *testing.T) {
 	res, err := parseStatResponse(&http.Response{
-		Body: ioutil.NopCloser(strings.NewReader(response)),
+		Body: io.NopCloser(strings.NewReader(response)),
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/client/upload.go
+++ b/pkg/client/upload.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"mime/multipart"
 	"net/http"
@@ -364,7 +363,7 @@ func (c *Client) Upload(ctx context.Context, h *UploadHandle) (*PutResult, error
 	if h.Vivify {
 		req.Header.Add("X-Camlistore-Vivify", "1")
 	}
-	req.Body = ioutil.NopCloser(pipeReader)
+	req.Body = io.NopCloser(pipeReader)
 	req.ContentLength = getMultipartOverhead() + bodySize + int64(len(blobrefStr))*2
 	resp, err := c.doReqGated(req)
 	if err != nil {
@@ -496,7 +495,7 @@ func (c *Client) wholeRef(contents io.Reader) ([]blob.Ref, error) {
 	}
 	td := hashutil.NewTrackDigestReader(contents)
 	td.DoLegacySHA1 = hasLegacySHA1
-	if _, err := io.Copy(ioutil.Discard, td); err != nil {
+	if _, err := io.Copy(io.Discard, td); err != nil {
 		return nil, err
 	}
 	refs := []blob.Ref{blob.RefFromHash(td.Hash())}

--- a/pkg/deploy/gce/handler.go
+++ b/pkg/deploy/gce/handler.go
@@ -25,7 +25,6 @@ import (
 	"fmt"
 	"html/template"
 	"io"
-	"io/ioutil"
 	"log"
 	"math/rand"
 	"net/http"
@@ -244,7 +243,7 @@ func (h *DeployHandler) authenticatedClient() (project string, hc *http.Client, 
 	project = os.Getenv("CAMLI_GCE_PROJECT")
 	accountFile := os.Getenv("CAMLI_GCE_SERVICE_ACCOUNT")
 	if project != "" && accountFile != "" {
-		data, errr := ioutil.ReadFile(accountFile)
+		data, errr := os.ReadFile(accountFile)
 		err = errr
 		if err != nil {
 			return
@@ -276,7 +275,7 @@ func (h *DeployHandler) refreshCamliVersion() error {
 		return err
 	}
 	defer resp.Body.Close()
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}
@@ -835,7 +834,7 @@ func (h *DeployHandler) instanceConf(ctx context.Context, br blob.Ref) (*Instanc
 		return nil, fmt.Errorf("could not fetch conf at %v: %v", br, err)
 	}
 	defer rc.Close()
-	contents, err := ioutil.ReadAll(rc)
+	contents, err := io.ReadAll(rc)
 	if err != nil {
 		return nil, fmt.Errorf("could not read conf in blob %v: %v", br, err)
 	}
@@ -887,7 +886,7 @@ func dataStores() (blobserver.Storage, sorted.KeyValue, error) {
 	dataDir := os.Getenv("CAMLI_GCE_DATA")
 	if dataDir == "" {
 		var err error
-		dataDir, err = ioutil.TempDir("", "camli-gcedeployer-data")
+		dataDir, err = os.MkdirTemp("", "camli-gcedeployer-data")
 		if err != nil {
 			return nil, nil, err
 		}

--- a/pkg/fs/mut.go
+++ b/pkg/fs/mut.go
@@ -24,7 +24,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -733,7 +732,7 @@ func (n *mutFile) Setattr(ctx context.Context, req *fuse.SetattrRequest, res *fu
 }
 
 func (n *mutFile) newHandle(body io.Reader) (fs.Handle, error) {
-	tmp, err := ioutil.TempFile("", "camli-")
+	tmp, err := os.CreateTemp("", "camli-")
 	if err == nil && body != nil {
 		_, err = io.Copy(tmp, body)
 	}

--- a/pkg/gpgchallenge/gpg.go
+++ b/pkg/gpgchallenge/gpg.go
@@ -65,7 +65,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net"
 	"net/http"
@@ -661,7 +660,7 @@ func (h *clientHandler) handleChallenge(w http.ResponseWriter, r *http.Request) 
 		http.Error(w, stickyErr.Error(), http.StatusMethodNotAllowed)
 		return
 	}
-	nonce, err := ioutil.ReadAll(r.Body)
+	nonce, err := io.ReadAll(r.Body)
 	if err != nil {
 		stickyErr = err
 		http.Error(w, err.Error(), 500)
@@ -701,7 +700,7 @@ func (h *clientHandler) handleACK(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, stickyErr.Error(), http.StatusBadRequest)
 		return
 	}
-	ack, err := ioutil.ReadAll(r.Body)
+	ack, err := io.ReadAll(r.Body)
 	if err != nil {
 		stickyErr = err
 		http.Error(w, err.Error(), 500)
@@ -726,7 +725,7 @@ func (cl *Client) getToken(serverAddr string) (string, error) {
 		return "", err
 	}
 	defer resp.Body.Close()
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", err
 	}
@@ -763,7 +762,7 @@ func (cl *Client) sendClaim(server, token string) error {
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusNoContent {
-		msg, err := ioutil.ReadAll(resp.Body)
+		msg, err := io.ReadAll(resp.Body)
 		if err == nil {
 			return fmt.Errorf("unexpected claim response: %v, %v", resp.Status, string(msg))
 		}

--- a/pkg/importer/feed/feed.go
+++ b/pkg/importer/feed/feed.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"html/template"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"net/url"
@@ -227,7 +226,7 @@ func doGet(ctx context.Context, url string) ([]byte, error) {
 	if res.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("Get request on %s failed with: %s", url, res.Status)
 	}
-	return ioutil.ReadAll(io.LimitReader(res.Body, 8<<20))
+	return io.ReadAll(io.LimitReader(res.Body, 8<<20))
 }
 
 func (im *imp) ServeSetup(w http.ResponseWriter, r *http.Request, ctx *importer.SetupContext) error {

--- a/pkg/importer/picasa/picasa_test.go
+++ b/pkg/importer/picasa/picasa_test.go
@@ -19,10 +19,10 @@ package picasa
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"net/url"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -132,7 +132,7 @@ func testImportAlbums(t *testing.T, data testData, caseNum int) {
 var rJPGurl = regexp.MustCompile(`url="([^"]*[.](?:jpg|JPG))"`)
 
 func TestImportAlbums(t *testing.T) {
-	fis, err := ioutil.ReadDir("testdata")
+	fis, err := os.ReadDir("testdata")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -156,7 +156,7 @@ func TestImportAlbums(t *testing.T) {
 			response, URL = resp, U
 		}
 
-		b, err := ioutil.ReadFile(fn)
+		b, err := os.ReadFile(fn)
 		if err != nil {
 			t.Logf("Cannot read %q: %v", fn, err)
 			continue

--- a/pkg/importer/pinboard/pinboard.go
+++ b/pkg/importer/pinboard/pinboard.go
@@ -46,7 +46,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"html/template"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"strings"
@@ -294,7 +294,7 @@ func (r *run) importBatch(authToken string, parent *importer.Object) (keepTrying
 		return false, fmt.Errorf("Unexpected status code %v fetching %v", resp.StatusCode, u)
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/importer/twitter/twitter.go
+++ b/pkg/importer/twitter/twitter.go
@@ -25,7 +25,7 @@ import (
 	"errors"
 	"fmt"
 	"html"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"net/url"
@@ -473,7 +473,7 @@ func tweetsFromZipFile(zf *zip.File) (tweets []*zipTweetItem, err error) {
 	if err != nil {
 		return nil, err
 	}
-	slurp, err := ioutil.ReadAll(rc)
+	slurp, err := io.ReadAll(rc)
 	rc.Close()
 	if err != nil {
 		return nil, err

--- a/pkg/index/indextest/tests.go
+++ b/pkg/index/indextest/tests.go
@@ -24,7 +24,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net/url"
 	"os"
@@ -339,7 +338,7 @@ func Index(t *testing.T, initIdx func() *index.Index) {
 		for i := 1; i <= 8; i++ {
 			fileBase := fmt.Sprintf("f%d-exif.jpg", i)
 			fileName := filepath.Join(camliRootPath, "pkg", "images", "testdata", fileBase)
-			contents, err := ioutil.ReadFile(fileName)
+			contents, err := os.ReadFile(fileName)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -356,7 +355,7 @@ func Index(t *testing.T, initIdx func() *index.Index) {
 		}
 		uploadFile := func(file string, modTime time.Time) (fileRef, wholeRef blob.Ref) {
 			fileName := filepath.Join(camliRootPath, "pkg", "index", "indextest", "testdata", file)
-			contents, err := ioutil.ReadFile(fileName)
+			contents, err := os.ReadFile(fileName)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/index/sqlite/sqlite_test.go
+++ b/pkg/index/sqlite/sqlite_test.go
@@ -19,7 +19,6 @@ package sqlite_test
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"sync"
@@ -36,7 +35,7 @@ import (
 )
 
 func newSorted(t *testing.T) (kv sorted.KeyValue, clean func()) {
-	f, err := ioutil.TempFile("", "sqlite-test")
+	f, err := os.CreateTemp("", "sqlite-test")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/index/stress/index_test.go
+++ b/pkg/index/stress/index_test.go
@@ -22,7 +22,6 @@ import (
 	"flag"
 	"hash"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -55,7 +54,7 @@ var (
 )
 
 func benchmarkPopulate(b *testing.B, dbname string, sortedProvider func(dbfile string) (sorted.KeyValue, error)) {
-	tempDir, err := ioutil.TempDir(*flagTempDir, "camli-index-stress")
+	tempDir, err := os.MkdirTemp(*flagTempDir, "camli-index-stress")
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -199,7 +198,7 @@ func BenchmarkInterruptSQLite(b *testing.B) {
 }
 
 func benchmarkAll(b *testing.B, dbname string, sortedProvider func(dbfile string) (sorted.KeyValue, error)) {
-	tempDir, err := ioutil.TempDir(*flagTempDir, "camli-index-stress")
+	tempDir, err := os.MkdirTemp(*flagTempDir, "camli-index-stress")
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/pkg/jsonsign/keys.go
+++ b/pkg/jsonsign/keys.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -42,7 +41,7 @@ const publicKeyMaxSize = 256 * 1024
 // The returned armoredKey is a copy of the contents read.
 func ParseArmoredPublicKey(r io.Reader) (fingerprint, armoredKey string, err error) {
 	var buf bytes.Buffer
-	pk, err := openArmoredPublicKeyFile(ioutil.NopCloser(io.TeeReader(r, &buf)))
+	pk, err := openArmoredPublicKeyFile(io.NopCloser(io.TeeReader(r, &buf)))
 	if err != nil {
 		return
 	}

--- a/pkg/schema/fileread_test.go
+++ b/pkg/schema/fileread_test.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"testing"
@@ -153,7 +152,7 @@ func TestReader(t *testing.T) {
 			continue
 		}
 		skipBytes(fr, rt.skip)
-		all, err := ioutil.ReadAll(fr)
+		all, err := io.ReadAll(fr)
 		if err != nil {
 			t.Errorf("read error on test %d: %v", idx, err)
 			continue
@@ -200,7 +199,7 @@ func TestReaderSeekStress(t *testing.T) {
 		}
 
 		skipBytes(fr, uint64(off))
-		got, err := ioutil.ReadAll(fr)
+		got, err := io.ReadAll(fr)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -389,7 +388,7 @@ func TestForeachChunkAllSchemaBlobs(t *testing.T) {
 		if err != nil {
 			t.Fatalf("%s: %v", name, err)
 		}
-		all, err := ioutil.ReadAll(fr)
+		all, err := io.ReadAll(fr)
 		if err != nil {
 			t.Fatalf("%s: %v", name, err)
 		}

--- a/pkg/schema/filereader.go
+++ b/pkg/schema/filereader.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"sync"
@@ -343,7 +342,7 @@ func (fr *FileReader) readerForOffset(ctx context.Context, off int64) (io.ReadCl
 	case p0.BlobRef.Valid() && p0.BytesRef.Valid():
 		return nil, fmt.Errorf("part illegally contained both a blobRef and bytesRef")
 	case !p0.BlobRef.Valid() && !p0.BytesRef.Valid():
-		return ioutil.NopCloser(
+		return io.NopCloser(
 			io.LimitReader(zeroReader{},
 				int64(p0.Size-uint64(offRemain)))), nil
 	case p0.BlobRef.Valid():
@@ -360,7 +359,7 @@ func (fr *FileReader) readerForOffset(ctx context.Context, off int64) (io.ReadCl
 			io.Closer
 		}{
 			byteReader,
-			ioutil.NopCloser(nil),
+			io.NopCloser(nil),
 		}
 	case p0.BytesRef.Valid():
 		var ss *superset

--- a/pkg/schema/schema_test.go
+++ b/pkg/schema/schema_test.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -79,7 +78,7 @@ func TestSymlink(t *testing.T) {
 	}
 
 	// Shouldn't be accessed:
-	if err := ioutil.WriteFile(filepath.Join(td, "test-target"), []byte("foo bar"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(td, "test-target"), []byte("foo bar"), 0644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -528,7 +527,7 @@ func TestIssue305(t *testing.T) {
 
 func TestStaticFileAndStaticSymlink(t *testing.T) {
 	// TODO (marete): Split this into two test functions.
-	fd, err := ioutil.TempFile("", "schema-test-")
+	fd, err := os.CreateTemp("", "schema-test-")
 	if err != nil {
 		t.Fatalf("io.TempFile(): %v", err)
 	}

--- a/pkg/schema/sign.go
+++ b/pkg/schema/sign.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 	"time"
@@ -93,7 +92,7 @@ func NewSigner(pubKeyRef blob.Ref, armoredPubKey io.Reader, privateKeySource int
 			ServerMode: true, // shouldn't matter, since we're supplying the rest of the fields
 			Fetcher: memoryBlobFetcher{
 				pubKeyRef: func() (uint32, io.ReadCloser) {
-					return uint32(len(armoredPubKeyString)), ioutil.NopCloser(strings.NewReader(armoredPubKeyString))
+					return uint32(len(armoredPubKeyString)), io.NopCloser(strings.NewReader(armoredPubKeyString))
 				},
 			},
 			EntityFetcher: entityFetcherFunc(func(wantFingerprint string) (*openpgp.Entity, error) {

--- a/pkg/search/describe_test.go
+++ b/pkg/search/describe_test.go
@@ -19,7 +19,7 @@ package search_test
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -150,7 +150,7 @@ func searchDescribeSetup(t *testing.T) indexAndOwner {
 			t.Fatalf("looking up perkeep.org location in $GOPATH: %v", err)
 		}
 		fileName := filepath.Join(camliRootPath, "pkg", "search", "testdata", file)
-		contents, err := ioutil.ReadFile(fileName)
+		contents, err := os.ReadFile(fileName)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/search/handler.go
+++ b/pkg/search/handler.go
@@ -22,7 +22,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"net/url"
@@ -974,7 +974,7 @@ func (sh *Handler) getNamed(ctx context.Context, name string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	result, err := ioutil.ReadAll(reader)
+	result, err := io.ReadAll(reader)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/search/handler_test.go
+++ b/pkg/search/handler_test.go
@@ -22,9 +22,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"reflect"
 	"sort"
@@ -630,7 +630,7 @@ func initTests() []handlerTest {
 				}
 				uploadFile := func(file string, modTime time.Time) blob.Ref {
 					fileName := filepath.Join(camliRootPath, "pkg", "index", "indextest", "testdata", file)
-					contents, err := ioutil.ReadFile(fileName)
+					contents, err := os.ReadFile(fileName)
 					if err != nil {
 						panic(err)
 					}
@@ -702,7 +702,7 @@ func initTests() []handlerTest {
 				}
 				uploadFile := func(file string, modTime time.Time) blob.Ref {
 					fileName := filepath.Join(camliRootPath, "pkg", "index", "indextest", "testdata", file)
-					contents, err := ioutil.ReadFile(fileName)
+					contents, err := os.ReadFile(fileName)
 					if err != nil {
 						panic(err)
 					}

--- a/pkg/search/query_test.go
+++ b/pkg/search/query_test.go
@@ -25,8 +25,8 @@ import (
 	"fmt"
 	"image"
 	"image/jpeg"
-	"io/ioutil"
 	"math/rand"
+	"os"
 	"path/filepath"
 	"reflect"
 	"sort"
@@ -600,7 +600,7 @@ func TestQueryPermanodeLocation(t *testing.T) {
 		}
 		uploadFile := func(file string, modTime time.Time) blob.Ref {
 			fileName := filepath.Join(camliRootPath, "pkg", "search", "testdata", file)
-			contents, err := ioutil.ReadFile(fileName)
+			contents, err := os.ReadFile(fileName)
 			if err != nil {
 				panic(err)
 			}
@@ -636,7 +636,7 @@ func TestQueryFileLocation(t *testing.T) {
 		}
 		uploadFile := func(file string, modTime time.Time) blob.Ref {
 			fileName := filepath.Join(camliRootPath, "pkg", "search", "testdata", file)
-			contents, err := ioutil.ReadFile(fileName)
+			contents, err := os.ReadFile(fileName)
 			if err != nil {
 				panic(err)
 			}
@@ -2038,7 +2038,7 @@ func BenchmarkQueryPermanodeLocation(b *testing.B) {
 		}
 		uploadFile := func(file string, modTime time.Time) blob.Ref {
 			fileName := filepath.Join(camliRootPath, "pkg", "search", "testdata", file)
-			contents, err := ioutil.ReadFile(fileName)
+			contents, err := os.ReadFile(fileName)
 			if err != nil {
 				panic(err)
 			}

--- a/pkg/server/download.go
+++ b/pkg/server/download.go
@@ -23,7 +23,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
@@ -158,7 +157,7 @@ func (dh *DownloadHandler) fileInfo(ctx context.Context, file blob.Ref) (fi file
 			name:    b.FileName(),
 			mode:    b.FileMode(),
 			rs:      readerutil.NewFakeSeeker(rd, size),
-			close:   ioutil.NopCloser(rd).Close,
+			close:   io.NopCloser(rd).Close,
 		}
 		return fi, false, nil
 	}
@@ -474,7 +473,7 @@ func (dh *DownloadHandler) checkFiles(ctx context.Context, parentPath string, fi
 		if err != nil {
 			return fmt.Errorf("could not open %v: %v", br, err)
 		}
-		_, err = io.Copy(ioutil.Discard, fr)
+		_, err = io.Copy(io.Discard, fr)
 		fr.Close()
 		if err != nil {
 			return fmt.Errorf("could not read %v: %v", br, err)

--- a/pkg/server/image.go
+++ b/pkg/server/image.go
@@ -26,7 +26,6 @@ import (
 	"image/jpeg"
 	"image/png"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"strconv"
@@ -133,7 +132,7 @@ func (ih *ImageHandler) cached(ctx context.Context, br blob.Ref) (io.ReadCloser,
 	if err != nil {
 		return nil, err
 	}
-	slurp, err := ioutil.ReadAll(rsc)
+	slurp, err := io.ReadAll(rsc)
 	rsc.Close()
 	if err != nil {
 		return nil, err
@@ -145,7 +144,7 @@ func (ih *ImageHandler) cached(ctx context.Context, br blob.Ref) (io.ReadCloser,
 		if imageDebug {
 			log.Printf("Image Cache: hit: %v\n", br)
 		}
-		return ioutil.NopCloser(bytes.NewReader(slurp)), nil
+		return io.NopCloser(bytes.NewReader(slurp)), nil
 	}
 
 	// For large scaled images, the cached blob is a file schema blob referencing

--- a/pkg/server/import_share.go
+++ b/pkg/server/import_share.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"net/url"
@@ -104,7 +103,7 @@ func (si *shareImporter) imprt(ctx context.Context, br blob.Ref) error {
 	if err != nil {
 		return err
 	}
-	rc = ioutil.NopCloser(io.MultiReader(bytes.NewReader(body), rc))
+	rc = io.NopCloser(io.MultiReader(bytes.NewReader(body), rc))
 
 	switch b.Type() {
 	case "directory":

--- a/pkg/server/share.go
+++ b/pkg/server/share.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"strconv"
@@ -247,7 +246,7 @@ func (h *shareHandler) handleGetViaSharing(rw http.ResponseWriter, req *http.Req
 			}
 			defer rc.Close()
 			lr := io.LimitReader(rc, schema.MaxSchemaBlobSize)
-			slurpBytes, err := ioutil.ReadAll(lr)
+			slurpBytes, err := io.ReadAll(lr)
 			if err != nil {
 				return unauthorized(viaChainReadFailed,
 					"Fetch chain %d of %s failed in slurp: %v", i, br, err)

--- a/pkg/server/sync.go
+++ b/pkg/server/sync.go
@@ -24,7 +24,6 @@ import (
 	"fmt"
 	"html"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
@@ -676,7 +675,7 @@ func (sh *SyncHandler) copyBlob(ctx context.Context, sb blob.SizedRef) (err erro
 
 func (sh *SyncHandler) ReceiveBlob(ctx context.Context, br blob.Ref, r io.Reader) (sb blob.SizedRef, err error) {
 	// TODO: use ctx?
-	n, err := io.Copy(ioutil.Discard, r)
+	n, err := io.Copy(io.Discard, r)
 	if err != nil {
 		return
 	}

--- a/pkg/server/uploadhelper.go
+++ b/pkg/server/uploadhelper.go
@@ -18,7 +18,6 @@ package server
 
 import (
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 
@@ -65,7 +64,7 @@ func (ui *UIHandler) serveUploadHelper(rw http.ResponseWriter, req *http.Request
 			break
 		}
 		if part.FormName() == "modtime" {
-			payload, err := ioutil.ReadAll(part)
+			payload, err := io.ReadAll(part)
 			if err != nil {
 				log.Printf("ui uploadhelper: unable to read part for modtime: %v", err)
 				continue

--- a/pkg/serverinit/serverinit_test.go
+++ b/pkg/serverinit/serverinit_test.go
@@ -23,7 +23,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -139,7 +138,7 @@ func replaceRingPath(path string) ([]byte, error) {
 		return nil, fmt.Errorf("Could not get absolute path of %v: %v", relativeRing, err)
 	}
 	secRing = strings.Replace(secRing, `\`, `\\`, -1)
-	slurpBytes, err := ioutil.ReadFile(path)
+	slurpBytes, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}
@@ -173,7 +172,7 @@ func backslashEscape(b []byte) []byte {
 
 func testConfig(name string, t *testing.T) {
 	wantedError := func() error {
-		slurp, err := ioutil.ReadFile(strings.Replace(name, ".json", ".err", 1))
+		slurp, err := os.ReadFile(strings.Replace(name, ".json", ".err", 1))
 		if os.IsNotExist(err) {
 			return nil
 		}
@@ -216,7 +215,7 @@ func testConfig(name string, t *testing.T) {
 			t.Fatal(err)
 		}
 		contents = canonicalizeGolden(t, contents)
-		if err := ioutil.WriteFile(wantFile, contents, 0644); err != nil {
+		if err := os.WriteFile(wantFile, contents, 0644); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/pkg/sorted/kvfile/kvfile_test.go
+++ b/pkg/sorted/kvfile/kvfile_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package kvfile
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -28,7 +27,7 @@ import (
 )
 
 func TestKvfileKV(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "camlistore-kvfilekv_test")
+	tmpDir, err := os.MkdirTemp("", "camlistore-kvfilekv_test")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sorted/leveldb/leveldb_test.go
+++ b/pkg/sorted/leveldb/leveldb_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package leveldb
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -28,7 +27,7 @@ import (
 )
 
 func TestLeveldbKV(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "camlistore-leveldbkv_test")
+	tmpDir, err := os.MkdirTemp("", "camlistore-leveldbkv_test")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sorted/sqlite/sqlitekv_test.go
+++ b/pkg/sorted/sqlite/sqlitekv_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package sqlite
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -28,7 +27,7 @@ import (
 )
 
 func TestSQLiteKV(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "camlistore-sqlitekv_test")
+	tmpDir, err := os.MkdirTemp("", "camlistore-sqlitekv_test")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/test/diff.go
+++ b/pkg/test/diff.go
@@ -18,7 +18,6 @@ package test
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"os/exec"
 )
@@ -29,11 +28,11 @@ func Diff(a, b []byte) string {
 	if bytes.Equal(a, b) {
 		return ""
 	}
-	ta, err := ioutil.TempFile("", "")
+	ta, err := os.CreateTemp("", "")
 	if err != nil {
 		return err.Error()
 	}
-	tb, err := ioutil.TempFile("", "")
+	tb, err := os.CreateTemp("", "")
 	if err != nil {
 		return err.Error()
 	}

--- a/pkg/test/integration/camget_test.go
+++ b/pkg/test/integration/camget_test.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -176,7 +175,7 @@ func TestCamgetFile(t *testing.T) {
 	_ = test.MustRunCmd(t, w.Cmd("pk-get", "-o", outDir, "-contents", br))
 
 	fetchedName := filepath.Join(outDir, "test.txt")
-	b, err := ioutil.ReadFile(fetchedName)
+	b, err := os.ReadFile(fetchedName)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/test/integration/camlistore_test.go
+++ b/pkg/test/integration/camlistore_test.go
@@ -20,7 +20,6 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -167,7 +166,7 @@ func TestNoTestingLinking(t *testing.T) {
 }
 
 func mustWriteFile(t *testing.T, path, contents string) {
-	err := ioutil.WriteFile(path, []byte(contents), 0644)
+	err := os.WriteFile(path, []byte(contents), 0644)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/test/world.go
+++ b/pkg/test/world.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net"
 	"net/http"
@@ -98,7 +97,7 @@ func (w *World) SourceRoot() string {
 // Build builds the Perkeep binaries.
 func (w *World) Build() error {
 	var err error
-	w.tempDir, err = ioutil.TempDir("", "perkeep-test-")
+	w.tempDir, err = os.MkdirTemp("", "perkeep-test-")
 	if err != nil {
 		return err
 	}

--- a/server/perkeepd/perkeepd.go
+++ b/server/perkeepd/perkeepd.go
@@ -22,7 +22,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net"
 	"net/http"
@@ -127,7 +126,7 @@ func slurpURL(urls string, limit int64) ([]byte, error) {
 		return nil, err
 	}
 	defer res.Body.Close()
-	return ioutil.ReadAll(io.LimitReader(res.Body, limit))
+	return io.ReadAll(io.LimitReader(res.Body, limit))
 }
 
 // loadConfig returns the server's parsed config file, locating it using the provided arg.

--- a/server/perkeepd/ui/closure/closure.go
+++ b/server/perkeepd/ui/closure/closure.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path"
@@ -66,7 +65,7 @@ type fs struct {
 	m  map[string]*fileInfo // keyed by what Open gets. see Open's comment.
 }
 
-var nopCloser = ioutil.NopCloser(nil)
+var nopCloser = io.NopCloser(nil)
 
 // Open is called with names like "/goog/base.js", but the zip contains Files named like "closure/goog/base.js".
 func (s *fs) Open(name string) (http.File, error) {
@@ -103,7 +102,7 @@ func newFileInfo(zf *zip.File) (*fileInfo, error) {
 	if err != nil {
 		return nil, err
 	}
-	all, err := ioutil.ReadAll(rc)
+	all, err := io.ReadAll(rc)
 	if err != nil {
 		return nil, err
 	}

--- a/website/pk-web/dirtrees.go
+++ b/website/pk-web/dirtrees.go
@@ -31,27 +31,29 @@ type Directory struct {
 	Dirs     []*Directory // subdirectories
 }
 
+// dirEntry defines functions for determining whether
+// entry is a directory or a file.
 type dirEntry interface {
 	Name() string
 	IsDir() bool
 }
 
-func isGoFile(fi dirEntry) bool {
-	name := fi.Name()
-	return !fi.IsDir() &&
+func isGoFile(de dirEntry) bool {
+	name := de.Name()
+	return !de.IsDir() &&
 		len(name) > 0 && name[0] != '.' && // ignore .files
 		pathpkg.Ext(name) == ".go"
 }
 
-func isPkgFile(fi dirEntry) bool {
-	return isGoFile(fi) &&
-		!strings.HasSuffix(fi.Name(), "_test.go") && // ignore test files
-		!strings.HasSuffix(fi.Name(), fileembedPattern)
+func isPkgFile(de dirEntry) bool {
+	return isGoFile(de) &&
+		!strings.HasSuffix(de.Name(), "_test.go") && // ignore test files
+		!strings.HasSuffix(de.Name(), fileembedPattern)
 }
 
-func isPkgDir(fi dirEntry) bool {
-	name := fi.Name()
-	return fi.IsDir() && len(name) > 0 &&
+func isPkgDir(de dirEntry) bool {
+	name := de.Name()
+	return de.IsDir() && len(name) > 0 &&
 		name[0] != '_' && name[0] != '.' // ignore _files and .files
 }
 

--- a/website/pk-web/dirtrees.go
+++ b/website/pk-web/dirtrees.go
@@ -33,8 +33,11 @@ type Directory struct {
 
 // dirEntry defines functions for determining whether
 // entry is a directory or a file.
+// The interface is a common part of fs.FileInfo and fs.DirEntry.
 type dirEntry interface {
+	// Name is returns the base name of the file or subdirectory.
 	Name() string
+	// IsDir returns whether the entry describes a directory.
 	IsDir() bool
 }
 

--- a/website/pk-web/godoc.go
+++ b/website/pk-web/godoc.go
@@ -29,7 +29,6 @@ import (
 	"go/printer"
 	"go/token"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
@@ -349,7 +348,7 @@ func (p *tconv) Write(data []byte) (n int, err error) {
 
 func readTextTemplate(name string) *template.Template {
 	fileName := filepath.Join(*root, "tmpl", name)
-	data, err := ioutil.ReadFile(fileName)
+	data, err := os.ReadFile(fileName)
 	if err != nil {
 		log.Fatalf("ReadFile %s: %v", fileName, err)
 	}
@@ -369,7 +368,7 @@ func applyTextTemplate(t *template.Template, name string, data interface{}) []by
 }
 
 func serveTextFile(w http.ResponseWriter, r *http.Request, abspath, relpath, title string) {
-	src, err := ioutil.ReadFile(abspath)
+	src, err := os.ReadFile(abspath)
 	if err != nil {
 		log.Printf("ReadFile: %s", err)
 		serveError(w, r, relpath, err)

--- a/website/pk-web/pkweb.go
+++ b/website/pk-web/pkweb.go
@@ -27,7 +27,6 @@ import (
 	"fmt"
 	"html/template"
 	"io"
-	"io/ioutil"
 	"log"
 	"net"
 	"net/http"
@@ -226,7 +225,7 @@ func servePage(w http.ResponseWriter, r *http.Request, params pageParams) {
 
 func readTemplate(name string) *template.Template {
 	fileName := filepath.Join(*root, "tmpl", name)
-	data, err := ioutil.ReadFile(fileName)
+	data, err := os.ReadFile(fileName)
 	if err != nil {
 		log.Fatalf("ReadFile %s: %v", fileName, err)
 	}
@@ -436,7 +435,7 @@ func serveFile(w http.ResponseWriter, r *http.Request, absPath string) {
 		return
 	}
 
-	data, err := ioutil.ReadFile(absPath)
+	data, err := os.ReadFile(absPath)
 	if err != nil {
 		serveError(w, r, absPath, err)
 		return
@@ -522,7 +521,7 @@ func gceDeployHandlerConfig() (*gce.Config, error) {
 		return nil, err
 	}
 	configFile := filepath.Join(configDir, "launcher-config.json")
-	data, err := ioutil.ReadFile(configFile)
+	data, err := os.ReadFile(configFile)
 	if err != nil {
 		return nil, fmt.Errorf("error reading launcher-config.json (expected of type https://godoc.org/"+prodDomain+"/pkg/deploy/gce#Config): %v", err)
 	}
@@ -576,7 +575,7 @@ func gceDeployHandler(prefix string) (*gce.DeployHandler, error) {
 		return nil, fmt.Errorf("NewDeployHandlerFromConfig: %v", err)
 	}
 
-	pageBytes, err := ioutil.ReadFile(filepath.Join(*root, "tmpl", "page.html"))
+	pageBytes, err := os.ReadFile(filepath.Join(*root, "tmpl", "page.html"))
 	if err != nil {
 		return nil, err
 	}
@@ -792,7 +791,7 @@ func httpClient(projID string) *http.Client {
 	if *gceJWTFile == "" {
 		log.Fatal("Cannot initialize an authorized http Client without --gce_jwt_file")
 	}
-	jsonSlurp, err := ioutil.ReadFile(*gceJWTFile)
+	jsonSlurp, err := os.ReadFile(*gceJWTFile)
 	if err != nil {
 		log.Fatalf("Error reading --gce_jwt_file value: %v", err)
 	}
@@ -1088,7 +1087,7 @@ func fromGCS(filename string) ([]byte, error) {
 			return nil, fmt.Errorf("Error fetching GCS object %q in bucket %q: %v", key, prodBucket, err)
 		}
 		defer rc.Close()
-		return ioutil.ReadAll(rc)
+		return io.ReadAll(rc)
 	}
 	return slurp(filename)
 }


### PR DESCRIPTION
This PR replaces all usages `io/ioutil` package with `io` and `os` because `ioutil` is deprecated.

From [the ioutil doc](https://pkg.go.dev/io/ioutil):
> Deprecated: As of Go 1.16, the same functionality is now provided by package io or package os, and those implementations should be preferred in new code. See the specific function documentation for details.

