### PR TITLE
pkg: Fix comments for exported elements

### DIFF
--- a/pkg/blobserver/blobpacked/stream.go
+++ b/pkg/blobserver/blobpacked/stream.go
@@ -40,7 +40,7 @@ func (s *storage) StreamBlobs(ctx context.Context, dest chan<- blobserver.BlobAn
 type smallBlobStreamer struct{ sto *storage }
 type largeBlobStreamer struct{ sto *storage }
 
-// stream the loose blobs
+// StreamBlobs streams the loose blobs
 func (st smallBlobStreamer) StreamBlobs(ctx context.Context, dest chan<- blobserver.BlobAndToken, contToken string) (err error) {
 	small := st.sto.small
 	if bs, ok := small.(blobserver.BlobStreamer); ok {

--- a/pkg/blobserver/interface.go
+++ b/pkg/blobserver/interface.go
@@ -57,7 +57,7 @@ type BlobReceiver interface {
 
 // BlobStatter is the interface for checking the size and existence of blobs.
 type BlobStatter interface {
-	// Stat checks for the existence of blobs, calling fn in
+	// StatBlobs checks for the existence of blobs, calling fn in
 	// serial for each found blob, in any order, but with no
 	// duplicates. The blobs slice should not have duplicates.
 	//
@@ -75,7 +75,7 @@ type StatReceiver interface {
 }
 
 type BlobEnumerator interface {
-	// EnumerateBobs sends at most limit SizedBlobRef into dest,
+	// EnumerateBlobs sends at most limit SizedBlobRef into dest,
 	// sorted, as long as they are lexigraphically greater than
 	// after (if provided).
 	// limit will be supplied and sanity checked by caller.
@@ -101,10 +101,9 @@ type BlobAndToken struct {
 	Token string
 }
 
+// BlobStreamer is an optional interface that may be implemented by
+// Storage implementations.
 type BlobStreamer interface {
-	// BlobStream is an optional interface that may be implemented by
-	// Storage implementations.
-	//
 	// StreamBlobs sends blobs to dest in an unspecified order. It is
 	// expected that a Storage implementation implementing
 	// BlobStreamer will send blobs to dest in the most efficient
@@ -226,7 +225,7 @@ an optimization so clients can mix this value into their "is this file
 uploaded?" local cache keys.
 */
 type Generationer interface {
-	// Generation returns a Storage's initialization time and
+	// StorageGeneration returns a Storage's initialization time and
 	// and unique random string (or UUID).  Implementations
 	// should call ResetStorageGeneration on demand if no
 	// information is known.
@@ -234,7 +233,7 @@ type Generationer interface {
 	// storage target doesn't support the Generationer interface.
 	StorageGeneration() (initTime time.Time, random string, err error)
 
-	// ResetGeneration deletes the information returned by Generation
+	// ResetStorageGeneration deletes the information returned by Generation
 	// and re-generates it.
 	ResetStorageGeneration() error
 }

--- a/pkg/gc/gc.go
+++ b/pkg/gc/gc.go
@@ -79,7 +79,7 @@ type Enumerator interface {
 
 // ItemEnumerator enumerates all the edges out from an item.
 type ItemEnumerator interface {
-	// EnumerateItme is like Enuerator's Enumerate, but specific
+	// EnumerateItem is like Enumerator's Enumerate, but specific
 	// to the provided item.
 	EnumerateItem(context.Context, Item, chan<- Item) error
 }

--- a/pkg/importer/attrs.go
+++ b/pkg/importer/attrs.go
@@ -44,21 +44,21 @@ const (
 	// Found at http://schema.org/Person.
 	// Example: "John Smith".
 	AcctAttrName = "name"
-	// http://schema.org/givenName
+	// AcctAttrGivenName found at http://schema.org/givenName.
 	// Example: "John".
 	AcctAttrGivenName = "givenName"
-	// http://schema.org/familyName
+	// AcctAttrFamilyName found at http://schema.org/familyNameA.
 	// Example: "Smith".
 	AcctAttrFamilyName = "familyName"
 
 	// Generic item, object.
 
-	// ItemAttrID is the generic identifier of an item when nothing suitable and more specific
+	// AttrID is the generic identifier of an item when nothing suitable and more specific
 	// was found on http://schema.org. Usually a number.
 	AttrID = "ID"
-	// http://schema.org/name
+	// AttrName found at http://schema.org/name
 	AttrName = "name"
-	// Free-flowing text definition of a location or place, such
+	// AttrLocationText is free-flowing text definition of a location or place, such
 	// as a city name, or a full postal address.
 	AttrLocationText = "locationText"
 	// AttrURL is the item's original or origin URL.

--- a/pkg/importer/importer.go
+++ b/pkg/importer/importer.go
@@ -1023,7 +1023,7 @@ func (im *importer) Accounts() ([]*importerAcct, error) {
 	return accts, nil
 }
 
-// node returns the importer node. (not specific to a certain account
+// Node returns the importer node. (not specific to a certain account
 // on that importer site)
 //
 // It is a permanode with:

--- a/pkg/importer/pinboard/pinboard.go
+++ b/pkg/importer/pinboard/pinboard.go
@@ -365,7 +365,7 @@ func (r *run) importPost(post *apiPost, parent *importer.Object) (dup bool, err 
 		return false, err
 	}
 
-	//Check for duplicates
+	// Check for duplicates
 	if post.Meta != "" && postNode.Attr(attrPostMeta) == post.Meta {
 		return true, nil
 	}

--- a/pkg/index/corpus.go
+++ b/pkg/index/corpus.go
@@ -53,7 +53,7 @@ type Corpus struct {
 	building bool
 
 	// hasLegacySHA1 reports whether some SHA-1 blobs are indexed. It is set while
-	//building the corpus from the initial index scan.
+	// building the corpus from the initial index scan.
 	hasLegacySHA1 bool
 
 	// gen is incremented on every blob received.

--- a/pkg/index/interface.go
+++ b/pkg/index/interface.go
@@ -14,16 +14,16 @@ type Interface interface {
 	RLock()
 	RUnlock()
 
-	// os.ErrNotExist should be returned if the blob isn't known
+	// GetBlobMeta returns os.ErrNotExist if the blob isn't known.
 	GetBlobMeta(context.Context, blob.Ref) (camtypes.BlobMeta, error)
 
-	// Should return os.ErrNotExist if not found.
+	// GetFileInfo returns os.ErrNotExist if not found.
 	GetFileInfo(ctx context.Context, fileRef blob.Ref) (camtypes.FileInfo, error)
 
-	// Should return os.ErrNotExist if not found.
+	// GetImageInfo returns os.ErrNotExist if not found.
 	GetImageInfo(ctx context.Context, fileRef blob.Ref) (camtypes.ImageInfo, error)
 
-	// Should return os.ErrNotExist if not found.
+	// GetMediaTags return os.ErrNotExist if not found.
 	GetMediaTags(ctx context.Context, fileRef blob.Ref) (map[string]string, error)
 
 	// GetFileLocation returns the location info (currently Exif) of the fileRef.
@@ -63,7 +63,7 @@ type Interface interface {
 		limit int,
 		before time.Time) error
 
-	// SearchPermanodes finds permanodes matching the provided
+	// SearchPermanodesWithAttr finds permanodes matching the provided
 	// request and sends unique permanode blobrefs to dest.
 	// In particular, if request.FuzzyMatch is true, a fulltext
 	// search is performed (if supported by the attribute(s))
@@ -105,9 +105,9 @@ type Interface interface {
 	// limit <= 0 means unlimited.
 	GetDirMembers(ctx context.Context, dirRef blob.Ref, dest chan<- blob.Ref, limit int) error
 
-	// Given an owner key, a camliType 'claim', 'attribute' name,
-	// and specific 'value', find the most recent permanode that has
-	// a corresponding 'set-attribute' claim attached.
+	// PermanodeOfSignerAttrValue does the following: given an owner key, a camliType
+	// 'claim', 'attribute' name, and specific 'value', find the most recent permanode
+	// that has a corresponding 'set-attribute' claim attached.
 	// Returns os.ErrNotExist if none is found.
 	// Only attributes white-listed by IsIndexedAttribute are valid.
 	// TODO(bradfitz): ErrNotExist here is a weird error message ("file" not found). change.
@@ -126,10 +126,10 @@ type Interface interface {
 	// then the complete URL(s) of a target can be found.
 	PathsOfSignerTarget(ctx context.Context, signer, target blob.Ref) ([]*camtypes.Path, error)
 
-	// All Path claims for (signer, base, suffix)
+	// PathsLookup returns all Path claims for (signer, base, suffix)
 	PathsLookup(ctx context.Context, signer, base blob.Ref, suffix string) ([]*camtypes.Path, error)
 
-	// Most recent Path claim for (signer, base, suffix) as of
+	// PathLookup returns most recent Path claim for (signer, base, suffix) as of
 	// provided time 'at', or most recent if 'at' is nil.
 	PathLookup(ctx context.Context, signer, base blob.Ref, suffix string, at time.Time) (*camtypes.Path, error)
 

--- a/pkg/search/predicate.go
+++ b/pkg/search/predicate.go
@@ -72,7 +72,7 @@ type keyword interface {
 	// It should return true if it wishes to handle this search atom.
 	// An error if the number of arguments mismatches.
 	Match(a atom) (bool, error)
-	// Predicates will be called with the args array from an atom instance.
+	// Predicate will be called with the args array from an atom instance.
 	// Note that len(args) > 0 (see atom-struct comment above).
 	// It should return a pointer to a Constraint object, expressing the meaning of
 	// its keyword.

--- a/pkg/sorted/kv.go
+++ b/pkg/sorted/kv.go
@@ -155,7 +155,7 @@ type ReadTransaction interface {
 	Get(key string) (string, error)
 	Find(start, end string) Iterator
 
-	// End the transaction.
+	// Close ends the transaction.
 	Close() error
 }
 

--- a/pkg/test/loader.go
+++ b/pkg/test/loader.go
@@ -25,7 +25,6 @@ import (
 	"perkeep.org/pkg/blobserver"
 )
 
-// NewLoader
 func NewLoader() *Loader {
 	return &Loader{}
 }


### PR DESCRIPTION
This PR fixes the comment format for exported elements. Should be:
```
// ExportedElement <description>
ExportedElement ...
```