### PR TITLE
blobserver/gdrive: fix creating request with context

### DIFF
--- a/pkg/blobserver/google/drive/service/service.go
+++ b/pkg/blobserver/google/drive/service/service.go
@@ -140,7 +140,7 @@ func (s *DriveService) Fetch(ctx context.Context, title string) (body io.ReadClo
 	}
 
 	req, _ := http.NewRequest("GET", file.DownloadUrl, nil)
-	req.WithContext(ctx)
+	req = req.WithContext(ctx)
 	var resp *http.Response
 	if resp, err = s.client.Transport.RoundTrip(req); err != nil {
 		return

--- a/pkg/importer/twitter/twitter.go
+++ b/pkg/importer/twitter/twitter.go
@@ -328,7 +328,7 @@ func (im *imp) LongPoll(rctx *importer.RunContext) error {
 	req, _ := http.NewRequest("GET", "https://userstream.twitter.com/1.1/user.json", nil)
 	req.Header.Set("Authorization", oauthClient.AuthorizationHeader(accessCreds, "GET", req.URL, form))
 	req.URL.RawQuery = form.Encode()
-	req.Cancel = rctx.Context().Done()
+	req = req.WithContext(rctx.Context())
 
 	log.Printf("twitter: beginning long poll, awaiting new tweets...")
 	res, err := http.DefaultClient.Do(req)


### PR DESCRIPTION
- Fix creating a request with context.
- Remove deprecated usage of [Request.Cancel](https://pkg.go.dev/net/http#Request) channel in `pkg/importer/twitter/twitter.go`.

I choose `req = req.WithContext(ctx)` because it's already used in the codebase. In my opinion, it's nicer to use `http.NewRequestWithContext` for creating a request with context.