### PR TITLE
tests: use T.Setenv instead of os.Setenv

### DIFF
--- a/cmd/pk-put/camput_test.go
+++ b/cmd/pk-put/camput_test.go
@@ -123,8 +123,7 @@ func testWithTempDir(t *testing.T, fn func(tempDir string)) {
 
 	confDir := filepath.Join(tempDir, "conf")
 	mustMkdir(t, confDir, 0700)
-	defer os.Setenv("CAMLI_CONFIG_DIR", os.Getenv("CAMLI_CONFIG_DIR"))
-	os.Setenv("CAMLI_CONFIG_DIR", confDir)
+	t.Setenv("CAMLI_CONFIG_DIR", confDir)
 	if err := os.WriteFile(filepath.Join(confDir, "client-config.json"), []byte("{}"), 0644); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/images/fastjpeg/fastjpeg_test.go
+++ b/internal/images/fastjpeg/fastjpeg_test.go
@@ -114,9 +114,8 @@ func TestDecodeDownsample(t *testing.T) {
 // a subprocess to simulate unavailability.
 func TestUnavailable(t *testing.T) {
 	checkAvailability = sync.Once{}
-	defer os.Setenv("CAMLI_DISABLE_DJPEG", "0")
 	if ok, _ := strconv.ParseBool(os.Getenv("CAMLI_DISABLE_DJPEG")); !ok {
-		os.Setenv("CAMLI_DISABLE_DJPEG", "1")
+		t.Setenv("CAMLI_DISABLE_DJPEG", "1")
 		out, err := exec.Command(os.Args[0], "-test.v",
 			"-test.run=TestUnavailable$").CombinedOutput()
 		if err != nil {
@@ -149,14 +148,12 @@ func TestFailed(t *testing.T) {
 		t.Skip("djpeg isn't available.")
 	}
 
-	oldPath := os.Getenv("PATH")
-	defer os.Setenv("PATH", oldPath)
 	// Use djpeg that exits after calling false.
 	newPath, err := filepath.Abs("testdata")
 	if err != nil {
 		t.Fatal(err)
 	}
-	os.Setenv("PATH", newPath)
+	t.Setenv("PATH", newPath)
 	t.Log("PATH", os.Getenv("PATH"))
 	t.Log(exec.LookPath("djpeg"))
 

--- a/internal/osutil/paths_test.go
+++ b/internal/osutil/paths_test.go
@@ -69,8 +69,7 @@ func TestOpenCamliIncludeNoFile(t *testing.T) {
 	// Test that error occurs if no such file
 	const notExist = "this_config_doesnt_exist.config"
 
-	defer os.Setenv("CAMLI_CONFIG_DIR", os.Getenv("CAMLI_CONFIG_DIR"))
-	os.Setenv("CAMLI_CONFIG_DIR", filepath.Join(os.TempDir(), "/x/y/z/not-exist"))
+	t.Setenv("CAMLI_CONFIG_DIR", filepath.Join(os.TempDir(), "/x/y/z/not-exist"))
 
 	_, e := findCamliInclude(notExist)
 	if e == nil {
@@ -88,8 +87,7 @@ func TestOpenCamliIncludeCWD(t *testing.T) {
 	defer os.Remove(path)
 
 	// Setting CAMLI_CONFIG_DIR just to avoid triggering failInTests in CamliConfigDir
-	defer os.Setenv("CAMLI_CONFIG_DIR", os.Getenv("CAMLI_CONFIG_DIR"))
-	os.Setenv("CAMLI_CONFIG_DIR", "whatever") // Restore after test
+	t.Setenv("CAMLI_CONFIG_DIR", "whatever") // Restore after test
 	checkOpen(t, path)
 }
 
@@ -102,8 +100,7 @@ func TestOpenCamliIncludeDir(t *testing.T) {
 		t.Errorf("Couldn't create test config file, aborting test: %v", e)
 		return
 	}
-	os.Setenv("CAMLI_CONFIG_DIR", td)
-	defer os.Setenv("CAMLI_CONFIG_DIR", "")
+	t.Setenv("CAMLI_CONFIG_DIR", td)
 
 	checkOpen(t, name)
 }
@@ -117,19 +114,17 @@ func TestOpenCamliIncludePath(t *testing.T) {
 		t.Errorf("Couldn't create test config file, aborting test: %v", e)
 		return
 	}
-	defer os.Setenv("CAMLI_INCLUDE_PATH", "")
 
-	defer os.Setenv("CAMLI_CONFIG_DIR", os.Getenv("CAMLI_CONFIG_DIR"))
-	os.Setenv("CAMLI_CONFIG_DIR", filepath.Join(td, "/x/y/z/not-exist"))
+	t.Setenv("CAMLI_CONFIG_DIR", filepath.Join(td, "/x/y/z/not-exist"))
 
-	os.Setenv("CAMLI_INCLUDE_PATH", td)
+	t.Setenv("CAMLI_INCLUDE_PATH", td)
 	checkOpen(t, name)
 
 	const sep = string(filepath.ListSeparator)
-	os.Setenv("CAMLI_INCLUDE_PATH", "/not/a/camli/config/dir"+sep+td)
+	t.Setenv("CAMLI_INCLUDE_PATH", "/not/a/camli/config/dir"+sep+td)
 	checkOpen(t, name)
 
-	os.Setenv("CAMLI_INCLUDE_PATH", "/not/a/camli/config/dir"+sep+td+sep+"/another/fake/camli/dir")
+	t.Setenv("CAMLI_INCLUDE_PATH", "/not/a/camli/config/dir"+sep+td+sep+"/another/fake/camli/dir")
 	checkOpen(t, name)
 }
 

--- a/pkg/serverinit/serverinit_test.go
+++ b/pkg/serverinit/serverinit_test.go
@@ -252,11 +252,10 @@ func TestExpansionsInHighlevelConfig(t *testing.T) {
 		t.Fatalf("failed to find perkeep.org GOPATH root: %v", err)
 	}
 	const keyID = "26F5ABDA"
-	os.Setenv("TMP_EXPANSION_TEST", keyID)
-	os.Setenv("TMP_EXPANSION_SECRING", filepath.Join(camroot, filepath.FromSlash("pkg/jsonsign/testdata/test-secring.gpg")))
+	t.Setenv("TMP_EXPANSION_TEST", keyID)
+	t.Setenv("TMP_EXPANSION_SECRING", filepath.Join(camroot, filepath.FromSlash("pkg/jsonsign/testdata/test-secring.gpg")))
 	// Setting CAMLI_CONFIG_DIR to avoid triggering failInTests in osutil.PerkeepConfigDir
-	defer os.Setenv("CAMLI_CONFIG_DIR", os.Getenv("CAMLI_CONFIG_DIR")) // restore after test
-	os.Setenv("CAMLI_CONFIG_DIR", "whatever")
+	t.Setenv("CAMLI_CONFIG_DIR", "whatever")
 	conf, err := serverinit.Load([]byte(`
 {
     "auth": "localhost",
@@ -294,8 +293,7 @@ func TestInstallHandlers(t *testing.T) {
 	}
 
 	// Setting CAMLI_CONFIG_DIR to avoid triggering failInTests in osutil.PerkeepConfigDir
-	defer os.Setenv("CAMLI_CONFIG_DIR", os.Getenv("CAMLI_CONFIG_DIR")) // restore after test
-	os.Setenv("CAMLI_CONFIG_DIR", "whatever")
+	t.Setenv("CAMLI_CONFIG_DIR", "whatever")
 	lowConf, err := serverinit.Load(confData)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
[T.Setenv](https://pkg.go.dev/testing#T.Setenv):
> Setenv calls os.Setenv(key, value) and uses Cleanup to restore the environment variable to its original value after the test.

