### PR TITLE
cmd/pk-mount, pkg/fs: drop macOS FUSE support

### DIFF
--- a/.github/workflows/tests-linux.yml
+++ b/.github/workflows/tests-linux.yml
@@ -20,6 +20,9 @@ jobs:
       with:
         go-version: ${{ matrix.go-version }}
 
+    - name: Install fuse
+      run: sudo apt-get install --yes fuse3
+
     - name: Symlink source into GOPATH for devcam
       run: |
         mkdir $(go env GOPATH)/src

--- a/cmd/pk-mount/pkmount_other.go
+++ b/cmd/pk-mount/pkmount_other.go
@@ -1,5 +1,4 @@
-//go:build !linux && !darwin
-// +build !linux,!darwin
+//go:build !linux
 
 /*
 Copyright 2013 The Perkeep Authors

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module perkeep.org
 go 1.19
 
 require (
-	bazil.org/fuse v0.0.0-20200524192727-fb710f7dfd05
+	bazil.org/fuse v0.0.0-20230120002735-62a210ff1fd5
 	cloud.google.com/go v0.80.0
 	cloud.google.com/go/datastore v1.1.0
 	cloud.google.com/go/logging v1.3.0
@@ -35,6 +35,7 @@ require (
 	golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd
 	golang.org/x/oauth2 v0.0.0-20210628180205-a41e5a781914
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
+	golang.org/x/sys v0.4.0
 	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac
 	google.golang.org/api v0.42.0
 	gopkg.in/mgo.v2 v2.0.0-20160818020120-3f83fa500528
@@ -86,7 +87,6 @@ require (
 	golang.org/x/exp/typeparams v0.0.0-20220218215828-6cf2b201936e // indirect
 	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 // indirect
 	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 // indirect
-	golang.org/x/sys v0.0.0-20220928140112-f11e5e49a4ec // indirect
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/tools v0.1.11-0.20220513221640-090b14e8501f // indirect
@@ -125,5 +125,3 @@ exclude (
 )
 
 replace google.golang.org/grpc v1.14.0 => github.com/bradfitz/grpc-go v0.0.0-20170203184515-188a132adcfb
-
-replace bazil.org/fuse => bazil.org/fuse v0.0.0-20180421153158-65cc252bf669 // pin to latest version that supports macOS. see https://github.com/bazil/fuse/issues/224

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-bazil.org/fuse v0.0.0-20180421153158-65cc252bf669 h1:FNCRpXiquG1aoyqcIWVFmpTSKVcx2bQD38uZZeGtdlw=
-bazil.org/fuse v0.0.0-20180421153158-65cc252bf669/go.mod h1:Xbm+BRKSBEpa4q4hTSxohYNQpsxXPbPry4JJWOB3LB8=
+bazil.org/fuse v0.0.0-20230120002735-62a210ff1fd5 h1:A0NsYy4lDBZAC6QiYeJ4N+XuHIKBpyhAVRMHRQZKTeQ=
+bazil.org/fuse v0.0.0-20230120002735-62a210ff1fd5/go.mod h1:gG3RZAMXCa/OTes6rr9EwusmR1OH1tDDy+cg9c5YliY=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=
@@ -335,6 +335,7 @@ github.com/tgulacsi/picago v0.0.0-20171229130838-9e1ac2306c70 h1:elvpffAnrLcWnsu
 github.com/tgulacsi/picago v0.0.0-20171229130838-9e1ac2306c70/go.mod h1:YOW4MCz1GRh0aqedyC48A1CRXSHngOB/O/4+1rUjDQg=
 github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80 h1:nrZ3ySNYwJbSpD6ce9duiP+QkD3JuLCcWkdaehUS/3Y=
 github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80/go.mod h1:iFyPdL66DjUD96XmzVL3ZntbzcflLnznH0fr99w5VqE=
+github.com/tv42/httpunix v0.0.0-20191220191345-2ba4b9c3382c h1:u6SKchux2yDvFQnDHS3lPnIRmfVJ5Sxy3ao2SIdysLQ=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/visualfc/fastmod v1.3.6 h1:gFvAxk6VoEbk0JF1XP0KznbQl5hYJN9ZYhRYQy3pcKs=
@@ -545,8 +546,8 @@ golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210902050250-f475640dd07b/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211007075335-d3039528d8ac/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220928140112-f11e5e49a4ec h1:BkDtF2Ih9xZ7le9ndzTA7KJow28VbQW3odyk/8drmuI=
-golang.org/x/sys v0.0.0-20220928140112-f11e5e49a4ec/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.4.0 h1:Zr2JFtRQNX3BCZ8YtxRE9hNJYC8J6I1MVbMg6owUp18=
+golang.org/x/sys v0.4.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 h1:JGgROgKl9N8DuW20oFS5gxc+lE67/N3FcwmBPMe7ArY=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=

--- a/pkg/fs/at.go
+++ b/pkg/fs/at.go
@@ -1,5 +1,4 @@
-//go:build linux || darwin
-// +build linux darwin
+//go:build linux
 
 /*
 Copyright 2012 The Perkeep Authors

--- a/pkg/fs/debug.go
+++ b/pkg/fs/debug.go
@@ -1,5 +1,4 @@
-//go:build linux || darwin
-// +build linux darwin
+//go:build linux
 
 /*
 Copyright 2013 The Perkeep Authors
@@ -109,7 +108,6 @@ func (s *stat) Attr(ctx context.Context, a *fuse.Attr) error {
 	a.Size = uint64(len(s.content()))
 	a.Mtime = serverStart
 	a.Ctime = serverStart
-	a.Crtime = serverStart
 	return nil
 }
 

--- a/pkg/fs/fs.go
+++ b/pkg/fs/fs.go
@@ -1,5 +1,4 @@
-//go:build linux || darwin
-// +build linux darwin
+//go:build linux
 
 /*
 Copyright 2011 The Perkeep Authors
@@ -407,7 +406,6 @@ func (s staticFileNode) Attr(ctx context.Context, a *fuse.Attr) error {
 	a.Size = uint64(len(s))
 	a.Mtime = serverStart
 	a.Ctime = serverStart
-	a.Crtime = serverStart
 	return nil
 }
 

--- a/pkg/fs/mut.go
+++ b/pkg/fs/mut.go
@@ -1,5 +1,4 @@
-//go:build linux || darwin
-// +build linux darwin
+//go:build linux
 
 /*
 Copyright 2013 The Perkeep Authors
@@ -632,7 +631,6 @@ func (n *mutFile) Attr(ctx context.Context, a *fuse.Attr) error {
 	a.Mtime = n.modTime()
 	a.Atime = n.accessTime()
 	a.Ctime = serverStart
-	a.Crtime = serverStart
 	return nil
 }
 

--- a/pkg/fs/mut_test.go
+++ b/pkg/fs/mut_test.go
@@ -1,5 +1,4 @@
-//go:build linux || darwin
-// +build linux darwin
+//go:build linux
 
 /*
 Copyright 2014 The Perkeep Authors

--- a/pkg/fs/recent.go
+++ b/pkg/fs/recent.go
@@ -1,5 +1,4 @@
-//go:build linux || darwin
-// +build linux darwin
+//go:build linux
 
 /*
 Copyright 2013 The Perkeep Authors

--- a/pkg/fs/ro.go
+++ b/pkg/fs/ro.go
@@ -1,5 +1,4 @@
-//go:build linux || darwin
-// +build linux darwin
+//go:build linux
 
 /*
 Copyright 2013 The Perkeep Authors
@@ -302,7 +301,6 @@ func (n *roFile) Attr(ctx context.Context, a *fuse.Attr) error {
 		Mtime:  n.modTime(),
 		Atime:  n.accessTime(),
 		Ctime:  serverStart,
-		Crtime: serverStart,
 	}
 	return nil
 }

--- a/pkg/fs/root.go
+++ b/pkg/fs/root.go
@@ -1,5 +1,4 @@
-//go:build linux || darwin
-// +build linux darwin
+//go:build linux
 
 /*
 Copyright 2012 The Perkeep Authors

--- a/pkg/fs/roots.go
+++ b/pkg/fs/roots.go
@@ -1,5 +1,4 @@
-//go:build linux || darwin
-// +build linux darwin
+//go:build linux
 
 /*
 Copyright 2012 The Perkeep Authors

--- a/pkg/fs/rover.go
+++ b/pkg/fs/rover.go
@@ -1,5 +1,4 @@
-//go:build linux || darwin
-// +build linux darwin
+//go:build linux
 
 /*
 Copyright 2014 The Perkeep Authors
@@ -441,7 +440,6 @@ func (n *roFileVersion) Attr(ctx context.Context, a *fuse.Attr) error {
 		Mtime:  n.modTime(),
 		Atime:  n.accessTime(),
 		Ctime:  serverStart,
-		Crtime: serverStart,
 	}
 	return nil
 }

--- a/pkg/fs/time.go
+++ b/pkg/fs/time.go
@@ -1,5 +1,4 @@
-//go:build linux || darwin
-// +build linux darwin
+//go:build linux
 
 /*
 Copyright 2013 The Perkeep Authors

--- a/pkg/fs/time_test.go
+++ b/pkg/fs/time_test.go
@@ -1,5 +1,4 @@
-//go:build linux || darwin
-// +build linux darwin
+//go:build linux
 
 /*
 Copyright 2013 The Perkeep Authors

--- a/pkg/fs/util.go
+++ b/pkg/fs/util.go
@@ -1,5 +1,4 @@
-//go:build linux || darwin
-// +build linux darwin
+//go:build linux
 
 /*
 Copyright 2013 The Perkeep Authors

--- a/pkg/fs/versions.go
+++ b/pkg/fs/versions.go
@@ -1,5 +1,4 @@
-//go:build linux || darwin
-// +build linux darwin
+//go:build linux
 
 /*
 Copyright 2014 The Perkeep Authors

--- a/pkg/fs/xattr.go
+++ b/pkg/fs/xattr.go
@@ -1,5 +1,4 @@
-//go:build linux || darwin
-// +build linux darwin
+//go:build linux
 
 /*
 Copyright 2013 The Perkeep Authors

--- a/pkg/fs/z_test.go
+++ b/pkg/fs/z_test.go
@@ -1,5 +1,4 @@
-//go:build linux || darwin
-// +build linux darwin
+//go:build linux
 
 /*
 Copyright 2013 The Perkeep Authors.


### PR DESCRIPTION
Bazil/fuse no longer supports macOS
(https://github.com/bazil/fuse/issues/224) because osxfuse is no
longer open source (https://github.com/osxfuse/osxfuse/issues/590).

Also, Apple is making it harder and harder (eventually impossible?) to
install custom kernel modules:
https://github.com/macfuse/macfuse/wiki/Getting-Started

So just give up on macOS FUSE support for now. We can resurrect it
later via WebDAV and/or NFS server support.

Signed-off-by: Brad Fitzpatrick <brad@danga.com>
