### PR TITLE
Tests: using GOMOD for the source root to run integration tests outside GOPATH

### DIFF
--- a/clients/web/embed/closure/updatelibrary.go
+++ b/clients/web/embed/closure/updatelibrary.go
@@ -63,11 +63,11 @@ func init() {
 // dependencies generated for the UI js files, and compiles the list of
 // js files from the closure lib required for the UI.
 func fileList() ([]string, error) {
-	camliRootPath, err := osutil.GoPackagePath("perkeep.org")
+	srcRoot, err := osutil.PkSourceRoot()
 	if err != nil {
-		log.Fatal("Package perkeep.org not found in $GOPATH (or $GOPATH not defined).")
+		log.Fatalf("source root folder not found: %v", err)
 	}
-	uiDir := filepath.Join(camliRootPath, "server", "perkeepd", "ui")
+	uiDir := filepath.Join(srcRoot, "server", "perkeepd", "ui")
 	closureDepsFile := filepath.Join(closureGitDir, "closure", "goog", "deps.js")
 
 	f, err := os.Open(closureDepsFile)
@@ -269,12 +269,12 @@ func cpToDestDir() {
 // we should clone or update in closureGitDir (depending on
 // if a .git dir was found).
 func setup() string {
-	camliRootPath, err := osutil.GoPackagePath("perkeep.org")
+	srcRoot, err := osutil.PkSourceRoot()
 	if err != nil {
-		log.Fatal("Package perkeep.org not found in $GOPATH (or $GOPATH not defined).")
+		log.Fatalf("source root folder not found: %v", err)
 	}
-	destDir = filepath.Join(camliRootPath, "vendor", "embed", "closure", "lib")
-	closureGitDir = filepath.Join(camliRootPath, "tmp", "closure-lib")
+	destDir = filepath.Join(srcRoot, "vendor", "embed", "closure", "lib")
+	closureGitDir = filepath.Join(srcRoot, "tmp", "closure-lib")
 	op := "update"
 	_, err = os.Stat(closureGitDir)
 	if err != nil {

--- a/dev/update_closure_compiler.go
+++ b/dev/update_closure_compiler.go
@@ -47,11 +47,11 @@ func main() {
 		log.Fatal("Didn't find 'java' in $PATH. The Java Runtime Environment is needed to run the closure compiler.\n")
 	}
 
-	camliRootPath, err := osutil.GoPackagePath("perkeep.org")
+	srcRoot, err := osutil.PkSourceRoot()
 	if err != nil {
-		log.Fatal("Package perkeep.org not found in $GOPATH (or $GOPATH not defined).")
+		log.Fatalf("source root folder not found: %v", err)
 	}
-	destDir := filepath.Join(camliRootPath, "tmp", "closure-compiler")
+	destDir := filepath.Join(srcRoot, "tmp", "closure-compiler")
 	// check if compiler already exists
 	jarFile := filepath.Join(destDir, "compiler.jar")
 	_, err = os.Stat(jarFile)

--- a/internal/osutil/paths.go
+++ b/internal/osutil/paths.go
@@ -342,6 +342,21 @@ func NewJSONConfigParser() *jsonconfig.ConfigParser {
 	return &cp
 }
 
+// PkSourceRoot returns the root of the source tree, or an error.
+func PkSourceRoot() (string, error) {
+	root, err := GoModPackagePath()
+	if err == nil {
+		return root, nil
+	}
+	err = fmt.Errorf("could not found go.mod, trying GOPATH: %w", err)
+	root, errp := GoPackagePath("perkeep.org")
+	if errors.Is(errp, os.ErrNotExist) {
+		return "", fmt.Errorf("directory \"perkeep.org\" not found under GOPATH/src; "+
+			"can't run Perkeep integration tests: %v", errors.Join(err, errp))
+	}
+	return root, nil
+}
+
 // GoPackagePath returns the path to the provided Go package's
 // source directory.
 // pkg may be a path prefix without any *.go files.

--- a/internal/osutil/paths.go
+++ b/internal/osutil/paths.go
@@ -376,6 +376,30 @@ func GoPackagePath(pkg string) (path string, err error) {
 	return path, os.ErrNotExist
 }
 
+// GoModPackagePath return the absolute path for the go.mod file without "go.mod" suffix.
+func GoModPackagePath() (string, error) {
+	gmp := os.Getenv("GOMOD")
+	if gmp == "" {
+		cmd := exec.Command("go", "env", "GOMOD")
+		out, err := cmd.Output()
+		if err != nil {
+			return "", fmt.Errorf("could not run 'go env GOMOD': %v, %s", err, out)
+		}
+		gmp = strings.TrimSuffix(strings.TrimSpace(string(out)), "go.mod")
+		if gmp == "" {
+			return "", os.ErrNotExist
+		}
+	}
+	fi, err := os.Stat(gmp)
+	if err != nil {
+		return "", err
+	}
+	if !fi.IsDir() {
+		return "", fmt.Errorf("%s is not a directory: %w", gmp, os.ErrNotExist)
+	}
+	return gmp, nil
+}
+
 func failInTests() {
 	if buildinfo.TestingLinked() {
 		panic("Unexpected non-hermetic use of host configuration during testing. (alternatively: the 'testing' package got accidentally linked in)")

--- a/misc/docker/dock.go
+++ b/misc/docker/dock.go
@@ -292,11 +292,11 @@ func main() {
 	flag.Parse()
 	checkFlags()
 
-	camDir, err := osutil.GoPackagePath("perkeep.org")
+	srcRoot, err := osutil.PkSourceRoot()
 	if err != nil {
 		log.Fatalf("Error looking up perkeep.org dir: %v", err)
 	}
-	dockDir = filepath.Join(camDir, "misc", "docker")
+	dockDir = filepath.Join(srcRoot, "misc", "docker")
 
 	if *asCamlistore {
 		serverImage = "camlistore/server"

--- a/misc/release/make-release.go
+++ b/misc/release/make-release.go
@@ -64,7 +64,7 @@ var (
 )
 
 var (
-	pkDir      string
+	srcRoot    string
 	releaseDir string
 	workDir    string
 	goVersion  string
@@ -105,11 +105,11 @@ func main() {
 	checkFlags()
 
 	var err error
-	pkDir, err = osutil.GoPackagePath("perkeep.org")
+	srcRoot, err = osutil.PkSourceRoot()
 	if err != nil {
 		log.Fatalf("Error looking up perkeep.org dir: %v", err)
 	}
-	releaseDir = filepath.Join(pkDir, "misc", "release")
+	releaseDir = filepath.Join(srcRoot, "misc", "release")
 
 	workDir, err = os.MkdirTemp("", "pk-build_release")
 	if err != nil {
@@ -669,7 +669,7 @@ func genReleasePage(releaseData *ReleaseData) error {
 		return fmt.Errorf("could not execute template: %v", err)
 	}
 
-	releaseDocDir := filepath.Join(pkDir, filepath.FromSlash("doc/release"))
+	releaseDocDir := filepath.Join(srcRoot, filepath.FromSlash("doc/release"))
 	if err := os.MkdirAll(releaseDocDir, 0755); err != nil {
 		return err
 	}

--- a/pkg/importer/flickr/testdata.go
+++ b/pkg/importer/flickr/testdata.go
@@ -277,12 +277,12 @@ func fakePhotosPage(page, pages, perPage int, photoIds []string) string {
 }
 
 func fakePicture() string {
-	camliDir, err := osutil.GoPackagePath("perkeep.org")
+	srcRoot, err := osutil.PkSourceRoot()
 	if err == os.ErrNotExist {
 		log.Fatal("Directory \"perkeep.org\" not found under GOPATH/src; are you not running with devcam?")
 	}
 	if err != nil {
-		log.Fatalf("Error searching for \"perkeep.org\" under GOPATH: %v", err)
+		log.Fatalf("source root folder not found: %v", err)
 	}
-	return filepath.Join(camliDir, filepath.FromSlash("clients/web/embed/glitch/npc_piggy__x1_walk_png_1354829432.png"))
+	return filepath.Join(srcRoot, filepath.FromSlash("clients/web/embed/glitch/npc_piggy__x1_walk_png_1354829432.png"))
 }

--- a/pkg/importer/picasa/testdata.go
+++ b/pkg/importer/picasa/testdata.go
@@ -228,12 +228,12 @@ func fakePhotoEntry(photoNbr int, albumNbr int) picago.Entry {
 
 // TODO(mpl): refactor with twitter
 func fakePhoto() string {
-	camliDir, err := osutil.GoPackagePath("perkeep.org")
+	srcRoot, err := osutil.PkSourceRoot()
 	if err == os.ErrNotExist {
 		log.Fatal("Directory \"perkeep.org\" not found under GOPATH/src; are you not running with devcam?")
 	}
 	if err != nil {
-		log.Fatalf("Error searching for \"perkeep.org\" under GOPATH: %v", err)
+		log.Fatalf("source root folder not found: %v", err)
 	}
-	return filepath.Join(camliDir, filepath.FromSlash("clients/web/embed/glitch/npc_piggy__x1_walk_png_1354829432.png"))
+	return filepath.Join(srcRoot, filepath.FromSlash("clients/web/embed/glitch/npc_piggy__x1_walk_png_1354829432.png"))
 }

--- a/pkg/importer/swarm/testdata.go
+++ b/pkg/importer/swarm/testdata.go
@@ -269,12 +269,12 @@ func fakePhotoItem() *photoItem {
 
 // TODO(mpl): refactor with twitter
 func fakePhoto() string {
-	camliDir, err := osutil.GoPackagePath("perkeep.org")
+	srcRoot, err := osutil.PkSourceRoot()
 	if err == os.ErrNotExist {
 		log.Fatal("Directory \"perkeep.org\" not found under GOPATH/src; are you not running with devcam?")
 	}
 	if err != nil {
-		log.Fatalf("Error searching for \"perkeep.org\" under GOPATH: %v", err)
+		log.Fatalf("source root folder not found: %v", err)
 	}
-	return filepath.Join(camliDir, filepath.FromSlash("clients/web/embed/glitch/npc_piggy__x1_walk_png_1354829432.png"))
+	return filepath.Join(srcRoot, filepath.FromSlash("clients/web/embed/glitch/npc_piggy__x1_walk_png_1354829432.png"))
 }

--- a/pkg/importer/twitter/testdata.go
+++ b/pkg/importer/twitter/testdata.go
@@ -256,12 +256,12 @@ func fakeEntities(counter int) entities {
 }
 
 func fakePicture() string {
-	camliDir, err := osutil.GoPackagePath("perkeep.org")
+	camliDir, err := osutil.PkSourceRoot()
 	if err == os.ErrNotExist {
 		log.Fatal("Directory \"perkeep.org\" not found under GOPATH/src; are you not running with devcam?")
 	}
 	if err != nil {
-		log.Fatalf("Error searching for \"perkeep.org\" under GOPATH: %v", err)
+		log.Fatalf("source root folder not found: %v", err)
 	}
 	return filepath.Join(camliDir, filepath.FromSlash("clients/web/embed/glitch/npc_piggy__x1_walk_png_1354829432.png"))
 }

--- a/pkg/index/indextest/tests.go
+++ b/pkg/index/indextest/tests.go
@@ -271,11 +271,11 @@ Enpn/oOOfYFa5h0AFndZd1blMvruXfdAobjVABEBAAE=
 // NewIndexDeps returns an IndexDeps helper for populating and working
 // with the provided index for tests.
 func NewIndexDeps(index *index.Index) *IndexDeps {
-	camliRootPath, err := osutil.GoPackagePath("perkeep.org")
+	srcRoot, err := osutil.PkSourceRoot()
 	if err != nil {
-		log.Fatal("Package perkeep.org not found in $GOPATH or $GOPATH not defined")
+		log.Fatalf("source root folder not found: %v", err)
 	}
-	secretRingFile := filepath.Join(camliRootPath, "pkg", "jsonsign", "testdata", "test-secring.gpg")
+	secretRingFile := filepath.Join(srcRoot, "pkg", "jsonsign", "testdata", "test-secring.gpg")
 
 	id := &IndexDeps{
 		Index:            index,
@@ -331,13 +331,13 @@ func Index(t *testing.T, initIdx func() *index.Index) {
 
 	// TODO(bradfitz): add EXIF tests here, once that stuff is ready.
 	if false {
-		camliRootPath, err := osutil.GoPackagePath("perkeep.org")
+		srcRoot, err := osutil.PkSourceRoot()
 		if err != nil {
-			t.Fatal("Package perkeep.org not found in $GOPATH or $GOPATH not defined")
+			t.Fatalf("source root folder not found: %v", err)
 		}
 		for i := 1; i <= 8; i++ {
 			fileBase := fmt.Sprintf("f%d-exif.jpg", i)
-			fileName := filepath.Join(camliRootPath, "pkg", "images", "testdata", fileBase)
+			fileName := filepath.Join(srcRoot, "pkg", "images", "testdata", fileBase)
 			contents, err := os.ReadFile(fileName)
 			if err != nil {
 				t.Fatal(err)
@@ -349,12 +349,12 @@ func Index(t *testing.T, initIdx func() *index.Index) {
 	// Upload some files.
 	var jpegFileRef, exifFileRef, exifWholeRef, badExifWholeRef, nanExifWholeRef, mediaFileRef, mediaWholeRef, heicEXIFWholeRef blob.Ref
 	{
-		camliRootPath, err := osutil.GoPackagePath("perkeep.org")
+		srcRoot, err := osutil.PkSourceRoot()
 		if err != nil {
-			t.Fatal("Package perkeep.org not found in $GOPATH or $GOPATH not defined")
+			t.Fatalf("source root folder not found: %v", err)
 		}
 		uploadFile := func(file string, modTime time.Time) (fileRef, wholeRef blob.Ref) {
-			fileName := filepath.Join(camliRootPath, "pkg", "index", "indextest", "testdata", file)
+			fileName := filepath.Join(srcRoot, "pkg", "index", "indextest", "testdata", file)
 			contents, err := os.ReadFile(fileName)
 			if err != nil {
 				t.Fatal(err)

--- a/pkg/index/stress/index_test.go
+++ b/pkg/index/stress/index_test.go
@@ -372,11 +372,11 @@ type keyStuff struct {
 }
 
 func doKeyStuff(b *testing.B) keyStuff {
-	camliRootPath, err := osutil.GoPackagePath("perkeep.org")
+	srcRoot, err := osutil.PkSourceRoot()
 	if err != nil {
-		b.Fatal("Package perkeep.org not found in $GOPATH or $GOPATH not defined")
+		b.Fatalf("source root folder not found: %v", err)
 	}
-	secretRingFile := filepath.Join(camliRootPath, "pkg", "jsonsign", "testdata", "test-secring.gpg")
+	secretRingFile := filepath.Join(srcRoot, "pkg", "jsonsign", "testdata", "test-secring.gpg")
 	pubKey := `-----BEGIN PGP PUBLIC KEY BLOCK-----
 
 xsBNBEzgoVsBCAC/56aEJ9BNIGV9FVP+WzenTAkg12k86YqlwJVAB/VwdMlyXxvi

--- a/pkg/search/describe_test.go
+++ b/pkg/search/describe_test.go
@@ -145,11 +145,11 @@ func searchDescribeSetup(t *testing.T) indexAndOwner {
 	))
 
 	uploadFile := func(file string) blob.Ref {
-		camliRootPath, err := osutil.GoPackagePath("perkeep.org")
+		srcRoot, err := osutil.PkSourceRoot()
 		if err != nil {
-			t.Fatalf("looking up perkeep.org location in $GOPATH: %v", err)
+			t.Fatalf("source root folder not found: %v", err)
 		}
-		fileName := filepath.Join(camliRootPath, "pkg", "search", "testdata", file)
+		fileName := filepath.Join(srcRoot, "pkg", "search", "testdata", file)
 		contents, err := os.ReadFile(fileName)
 		if err != nil {
 			t.Fatal(err)

--- a/pkg/search/handler_test.go
+++ b/pkg/search/handler_test.go
@@ -126,11 +126,11 @@ var (
 // testSigner returns the signer, as well as its armored public key, from
 // pkg/jsonsign/testdata/test-secring.gpg
 func testSigner() *schema.Signer {
-	camliRootPath, err := osutil.GoPackagePath("perkeep.org")
+	srcRoot, err := osutil.PkSourceRoot()
 	if err != nil {
-		panic(fmt.Sprintf("error looking up perkeep.org's location in $GOPATH: %v", err))
+		panic(fmt.Sprintf("source root folder not found: %v", err))
 	}
-	ent, err := jsonsign.EntityFromSecring(indextest.KeyID, filepath.Join(camliRootPath, "pkg", "jsonsign", "testdata", "test-secring.gpg"))
+	ent, err := jsonsign.EntityFromSecring(indextest.KeyID, filepath.Join(srcRoot, "pkg", "jsonsign", "testdata", "test-secring.gpg"))
 	if err != nil {
 		panic(err)
 	}
@@ -624,12 +624,12 @@ func initTests() []handlerTest {
 				id := indextest.NewIndexDeps(idx)
 
 				// Upload a basic image
-				camliRootPath, err := osutil.GoPackagePath("perkeep.org")
+				srcRoot, err := osutil.PkSourceRoot()
 				if err != nil {
-					panic("Package perkeep.org not found in $GOPATH or $GOPATH not defined")
+					panic(fmt.Sprintf("source root folder not found: %v", err))
 				}
 				uploadFile := func(file string, modTime time.Time) blob.Ref {
-					fileName := filepath.Join(camliRootPath, "pkg", "index", "indextest", "testdata", file)
+					fileName := filepath.Join(srcRoot, "pkg", "index", "indextest", "testdata", file)
 					contents, err := os.ReadFile(fileName)
 					if err != nil {
 						panic(err)
@@ -696,12 +696,12 @@ func initTests() []handlerTest {
 				id := indextest.NewIndexDeps(idx)
 
 				// Upload a basic image
-				camliRootPath, err := osutil.GoPackagePath("perkeep.org")
+				srcRoot, err := osutil.PkSourceRoot()
 				if err != nil {
-					panic("Package perkeep.org not found in $GOPATH or $GOPATH not defined")
+					panic(fmt.Sprintf("source root folder not found: %v", err))
 				}
 				uploadFile := func(file string, modTime time.Time) blob.Ref {
-					fileName := filepath.Join(camliRootPath, "pkg", "index", "indextest", "testdata", file)
+					fileName := filepath.Join(srcRoot, "pkg", "index", "indextest", "testdata", file)
 					contents, err := os.ReadFile(fileName)
 					if err != nil {
 						panic(err)

--- a/pkg/search/query_test.go
+++ b/pkg/search/query_test.go
@@ -594,12 +594,12 @@ func TestQueryPermanodeLocation(t *testing.T) {
 		id.SetAttribute(p5, "longitude", "2.0")
 
 		// Upload a basic image
-		camliRootPath, err := osutil.GoPackagePath("perkeep.org")
+		srcRoot, err := osutil.PkSourceRoot()
 		if err != nil {
-			panic("Package perkeep.org not found in $GOPATH or $GOPATH not defined")
+			panic(fmt.Sprintf("source root folder not found: %v", err))
 		}
 		uploadFile := func(file string, modTime time.Time) blob.Ref {
-			fileName := filepath.Join(camliRootPath, "pkg", "search", "testdata", file)
+			fileName := filepath.Join(srcRoot, "pkg", "search", "testdata", file)
 			contents, err := os.ReadFile(fileName)
 			if err != nil {
 				panic(err)
@@ -630,12 +630,12 @@ func TestQueryFileLocation(t *testing.T) {
 		id := qt.id
 
 		// Upload a basic image
-		camliRootPath, err := osutil.GoPackagePath("perkeep.org")
+		srcRoot, err := osutil.PkSourceRoot()
 		if err != nil {
-			panic("Package perkeep.org not found in $GOPATH or $GOPATH not defined")
+			panic(fmt.Sprintf("source root folder not found: %v", err))
 		}
 		uploadFile := func(file string, modTime time.Time) blob.Ref {
-			fileName := filepath.Join(camliRootPath, "pkg", "search", "testdata", file)
+			fileName := filepath.Join(srcRoot, "pkg", "search", "testdata", file)
 			contents, err := os.ReadFile(fileName)
 			if err != nil {
 				panic(err)
@@ -2032,12 +2032,12 @@ func BenchmarkQueryPermanodeLocation(b *testing.B) {
 		id := qt.id
 
 		// Upload a basic image
-		camliRootPath, err := osutil.GoPackagePath("perkeep.org")
+		srcRoot, err := osutil.PkSourceRoot()
 		if err != nil {
-			panic("Package perkeep.org not found in $GOPATH or $GOPATH not defined")
+			panic(fmt.Sprintf("source root folder not found: %v", err))
 		}
 		uploadFile := func(file string, modTime time.Time) blob.Ref {
-			fileName := filepath.Join(camliRootPath, "pkg", "search", "testdata", file)
+			fileName := filepath.Join(srcRoot, "pkg", "search", "testdata", file)
 			contents, err := os.ReadFile(fileName)
 			if err != nil {
 				panic(err)

--- a/pkg/server/ui.go
+++ b/pkg/server/ui.go
@@ -179,9 +179,9 @@ func uiFromConfig(ld blobserver.Loader, conf jsonconfig.Obj) (h http.Handler, er
 				return nil, fmt.Errorf("Could not read static files: %v", err)
 			}
 			if len(files) == 0 {
-				ui.sourceRoot, err = osutil.GoPackagePath("perkeep.org")
+				ui.sourceRoot, err = osutil.PkSourceRoot()
 				if err != nil {
-					log.Printf("Warning: server not compiled with linked-in UI resources (HTML, JS, CSS), and perkeep.org not found in GOPATH.")
+					log.Printf("Warning: server not compiled with linked-in UI resources (HTML, JS, CSS), and source root folder not found: %v", err)
 				} else {
 					log.Printf("Using UI resources (HTML, JS, CSS) from disk, under %v", ui.sourceRoot)
 				}
@@ -628,7 +628,8 @@ func (ui *UIHandler) serveClosure(rw http.ResponseWriter, req *http.Request) {
 }
 
 // serveFromDiskOrStatic matches rx against req's path and serves the match either from disk (if non-nil) or from static (embedded in the binary).
-func (ui *UIHandler) serveFromDiskOrStatic(rw http.ResponseWriter, req *http.Request, rx *regexp.Regexp, disk http.Handler, static fs.FS) {
+func (ui *UIHandler) serveFromDiskOrStatic(rw http.ResponseWriter, req *http.Request, rx *regexp.Regexp,
+	disk http.Handler, static fs.FS) {
 	suffix := httputil.PathSuffix(req)
 	m := rx.FindStringSubmatch(suffix)
 	if m == nil {

--- a/pkg/serverinit/serverinit_test.go
+++ b/pkg/serverinit/serverinit_test.go
@@ -247,13 +247,13 @@ func canonicalizeGolden(t *testing.T, v []byte) []byte {
 }
 
 func TestExpansionsInHighlevelConfig(t *testing.T) {
-	camroot, err := osutil.GoPackagePath("perkeep.org")
+	srcRoot, err := osutil.PkSourceRoot()
 	if err != nil {
-		t.Fatalf("failed to find perkeep.org GOPATH root: %v", err)
+		t.Fatalf("source root folder not found: %v", err)
 	}
 	const keyID = "26F5ABDA"
 	t.Setenv("TMP_EXPANSION_TEST", keyID)
-	t.Setenv("TMP_EXPANSION_SECRING", filepath.Join(camroot, filepath.FromSlash("pkg/jsonsign/testdata/test-secring.gpg")))
+	t.Setenv("TMP_EXPANSION_SECRING", filepath.Join(srcRoot, filepath.FromSlash("pkg/jsonsign/testdata/test-secring.gpg")))
 	// Setting CAMLI_CONFIG_DIR to avoid triggering failInTests in osutil.PerkeepConfigDir
 	t.Setenv("CAMLI_CONFIG_DIR", "whatever")
 	conf, err := serverinit.Load([]byte(`
@@ -277,13 +277,13 @@ func TestExpansionsInHighlevelConfig(t *testing.T) {
 }
 
 func TestInstallHandlers(t *testing.T) {
-	camroot, err := osutil.GoPackagePath("perkeep.org")
+	srcRoot, err := osutil.PkSourceRoot()
 	if err != nil {
-		t.Fatalf("failed to find perkeep.org GOPATH root: %v", err)
+		t.Fatalf("source root folder not found: %v", err)
 	}
 	conf := serverinit.DefaultBaseConfig
 	conf.Identity = "26F5ABDA"
-	conf.IdentitySecretRing = filepath.Join(camroot, filepath.FromSlash("pkg/jsonsign/testdata/test-secring.gpg"))
+	conf.IdentitySecretRing = filepath.Join(srcRoot, filepath.FromSlash("pkg/jsonsign/testdata/test-secring.gpg"))
 	conf.MemoryStorage = true
 	conf.MemoryIndex = true
 

--- a/pkg/test/world.go
+++ b/pkg/test/world.go
@@ -56,21 +56,6 @@ type World struct {
 	serverErr error
 }
 
-// pkSourceRoot returns the root of the source tree, or an error.
-func pkSourceRoot() (string, error) {
-	root, err := osutil.GoModPackagePath()
-	if err == nil {
-		return root, nil
-	}
-	err = fmt.Errorf("could not found go.mod, trying GOPATH: %w", err)
-	root, errp := osutil.GoPackagePath("perkeep.org")
-	if errors.Is(errp, os.ErrNotExist) {
-		return "", fmt.Errorf("directory \"perkeep.org\" not found under GOPATH/src; "+
-			"can't run Perkeep integration tests: %v", errors.Join(err, errp))
-	}
-	return root, nil
-}
-
 // NewWorld returns a new test world.
 // It uses the GOPATH (explicit or implicit) to find the "perkeep.org" root.
 func NewWorld() (*World, error) {
@@ -81,7 +66,7 @@ func NewWorld() (*World, error) {
 // This cfg is the server config relative to pkg/test/testdata.
 // It uses the GOPATH (explicit or implicit) to find the "perkeep.org" root.
 func WorldFromConfig(cfg string) (*World, error) {
-	root, err := pkSourceRoot()
+	root, err := osutil.PkSourceRoot()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### TLDR

- move `PkSourceRoot` from `pkg/test/world.go` to `internal/osutil/paths.go`;
- migrate all calls from `osutil.GoPackagePath("perkeep.org")` to `osutil.PkSourceRoot()`;
- keep the variable name consistent (`camliRootPath`, `camDir`, etc. => `srcRoot`);
- The GOPATH way is still there as a fallback for compatibility.

Hi, 

While playing around to learn the code base, I tried to run the tests and got errors about `perkeep.org` not being in `GOPATH/src`. 

I thought it would be a good way to get acquainted with the code base. 
I hope I didn't overstep by changing too many things. 
All the tests are passing, including the integration tests.

Let me know what you would like to change in this PR, I'm just trying to be a good citizen. :)

 

For reference: https://go.dev/wiki/GOPATH