### PR TITLE
doc: fix broken links

### DIFF
--- a/doc/environment-vars.md
+++ b/doc/environment-vars.md
@@ -36,12 +36,10 @@ and
 `PERKEEP_CACHE_DIR` (string)
 or
 `CAMLI_CACHE_DIR` (string)
-: Path used by [pkg/osutil](/pkg/osutil) to override operating system specific
-  cache directory.
+: Path used by `internal/osutil` to override operating system specific cache directory.
 
 `CAMLI_CONFIG_DIR` (string)
-: Path used by pkg/osutil to override operating system specific configuration
-  directory.
+: Path used by `internal/osutil` to override operating system specific configuration directory.
 
 `CAMLI_DBNAME` (string)
 : Backend specific data source name (DSN).
@@ -85,7 +83,7 @@ files to be ignored by [pkg/client](/pkg/client) when uploading.
 
 `CAMLI_INCLUDE_PATH` (string)
 : Path to search for files.
-  Referenced in [pkg/osutil](/pkg/osutil) and used indirectly by
+  Referenced in `internal/osutil` and used indirectly by
   [go4.org/jsonconfig.ConfigParser](http://go4.org/jsonconfig#ConfigParser) to search for
   files mentioned in configurations.  This is used as a last resort after first
   checking the current directory and the Perkeep config directory. It should
@@ -162,7 +160,7 @@ files to be ignored by [pkg/client](/pkg/client) when uploading.
   without forcing a global reindexing.
 
 `CAMLI_VAR_DIR` (string)
-: Path used by [pkg/osutil](/pkg/osutil) to override operating system specific
+: Path used by `internal/osutil` to override operating system specific
   application storage directory. Generally unused.
 
 `CAMLI_S3_FAIL_PERCENT` (int)
@@ -189,7 +187,7 @@ files to be ignored by [pkg/client](/pkg/client) when uploading.
 : Used by [pkg/client](/pkg/client) to enable additional logging.
 
 `CAMLI_DEBUG_IMAGES` (bool)
-: Enable extra debugging in [pkg/images](/pkg/images) when decoding images.
+: Enable extra debugging in `internal/images` when decoding images.
   Used by indexers.
 
 `CAMLI_SHA1_ENABLED` (bool)

--- a/doc/prior-art.md
+++ b/doc/prior-art.md
@@ -17,7 +17,7 @@
     pioneered the idea of recursive content-addressable file systems.
 
 * [Monotone](http://www.monotone.ca/)'s "Certificates" are similar to Perkeep
-  claims. (See [terminology](terms.md#claims))
+  claims. (See [terminology](terms#claim))
 
 Probably more, though.  Contributions to this list are welcome!
 

--- a/doc/release/0.2.html
+++ b/doc/release/0.2.html
@@ -26,7 +26,7 @@ Or browse at Github: <a href="https://github.com/bradfitz/camlistore/tree/0.2">g
 <ul>
   <li><b>Encryption support.</b> It hasn't been audited yet, metadata compaction isn't quite done, and the simple-config-to-low-level-config translator isn't enabled yet, so consider it all beta. It's there to use if you know what you're doing, but the underlying format might yet change.</li>
   <li><b>Improved build system.</b> Our build by default now embeds all the <a href="https://developers.google.com/closure/library/">Closure</a> resources into the server binary, making deployment much easier: just one file (the server binary) to put on your server.</li>
-  <li><b>Easier initial setup.</b> More helpful initial configuration of <a href="/cmd/camput"><code>camput</code></a>, etc.</li>
+  <li><b>Easier initial setup.</b> More helpful initial configuration of <a href="https://github.com/perkeep/perkeep/tree/0.2/cmd/camput"><code>camput</code></a>, etc.</li>
   <li><b>Config files moved.</b> We now respect the <a href="http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html">XDG Base Directory Specification</a> on Unix systems. If you had your config files in <code>~/.camlistore/</code> before, move them to <code>~/.config/camlistore/</code>.</li>
   <li><b>Fixes</b>: <ul>
       <li>The SQLite backend now uses <a href="http://www.sqlite.org/draft/wal.html">WAL</a> when available, for improved throughput with high concurrency. A bug in our build system's detection of SQLite was also fixed.</li>

--- a/doc/release/monthly/2017-03-01.html
+++ b/doc/release/monthly/2017-03-01.html
@@ -17,7 +17,7 @@ https://df4a6661.camlistore.net.
 </p>
 
 <p id="scanningcabinet">
-Another notable addition, albeit experimental as well, is the <a href='/app/scanningcabinet'>Scanning Cabinet</a>
+Another notable addition, albeit experimental as well, is the <a href='https://github.com/perkeep/perkeep/tree/dc4d1650b3332a0257e6a856d3da57b1d28c0b58/app/scanningcabinet'>Scanning Cabinet</a>
 app, a <a href='https://camlistore.googlesource.com/camlistore/+/5a24ffd85429b3b39049358625f7a75007a40b23'>port</a>
 of <a href='https://github.com/bradfitz/scanningcabinet'>bradfitz/scanningcabinet</a>.
 </p>

--- a/doc/release/monthly/2017-04-05.html
+++ b/doc/release/monthly/2017-04-05.html
@@ -19,7 +19,7 @@ is limited to one item, but these limitations should be addressed soon.
 
 <p>
 Other notable changes for this release are improvements to the
-<a href='/app/scanningcabinet'>scanning cabinet</a>,
+<a href='https://github.com/perkeep/perkeep/tree/9e34d14ef5f240f35bd88d71495da0f6cbf99600/app/scanningcabinet'>scanning cabinet</a>,
 especially to its web user interface, and the introduction of a new
 importer for <a href="https://plaid.com">Plaid</a>, for financial transactions.
 </p>

--- a/doc/release/monthly/2017-05-05.html
+++ b/doc/release/monthly/2017-05-05.html
@@ -15,7 +15,7 @@ directory is then the item being shared (transitively).
 </p>
 
 <p>
-The Camlistore <a href="/launch">launcher</a> for Google Cloud was also
+The Camlistore <a href="https://github.com/perkeep/perkeep/blob/8f1a7df176de21d0d052c04db45b373c5c282fb1/website/camweb.go#L531">launcher</a> for Google Cloud was also
 improved: it can now create a Google Project, and configure it (enable the
 required Google Cloud APIs), on behalf of the user. After the project is
 created, the user still has to enable billing for the project before they can

--- a/doc/terms.md
+++ b/doc/terms.md
@@ -115,7 +115,7 @@ starts with <code>{</code> and is <a href="http://json.org/">valid JSON</a> in i
      on mutating an object (by all creating new, signed mutation schema blobs),
      the owner ultimately decides the policies on how the mutations are respected.</p>
 
-  <p>Example permanode blob:  (as generated with <code><a href="/cmd/pk put">pk put</a> --permanode</code>)</p>
+  <p>Example permanode blob:  (as generated with <code><a href="/cmd/pk-put">pk-put</a> --permanode</code>)</p>
 
      <pre class='sty' style="overflow: auto;">{"camliVersion": 1,
   "camliSigner": "sha1-c4da9d771661563a27704b91b67989e7ea1e50b8",


### PR DESCRIPTION
The PR fixes broken links on https://perkeep.org/ found by the [linkcheck](https://github.com/filiph/linkcheck).

<details><summary>linkcheck output</summary>
<p>

```
❯ linkcheck https://perkeep.org/
Done crawling.

https://perkeep.org/doc/environment-vars
- (69:17) 'pkg/osutil' => https://perkeep.org/pkg/osutil (HTTP 404)
- (112:14) 'pkg/osutil' => https://perkeep.org/pkg/osutil (HTTP 404)
- (170:17) 'pkg/osutil' => https://perkeep.org/pkg/osutil (HTTP 404)
- (193:30) 'pkg/images' => https://perkeep.org/pkg/images (HTTP 404)

https://perkeep.org/doc/prior-art
- (60:13) 'terminol..' => https://perkeep.org/doc/terms.md#claims (HTTP 200 but missing anchor)
  - redirect path:
    - https://perkeep.org/doc/terms.md (302)
    - /doc/terms (200)

https://perkeep.org/doc/release/0.2
- (64:73) 'camput' => https://perkeep.org/cmd/camput (HTTP 404)

https://perkeep.org/doc/release/monthly/2017-03-01
- (54:62) 'Scanning..' => https://perkeep.org/app/scanningcabinet (HTTP 404)

https://perkeep.org/doc/release/monthly/2017-04-05
- (56:0) 'scanning..' => https://perkeep.org/app/scanningcabinet (HTTP 404)

https://perkeep.org/doc/release/monthly/2017-05-05
- (52:15) 'launcher' => https://perkeep.org/launch (HTTP 301 => 500)
  - redirect path:
    - https://perkeep.org/launch (301)
    - /launch/ (500)

https://perkeep.org/doc/terms
- (153:55) 'pk put' => https://perkeep.org/cmd/pk%20put (HTTP 404)
- (153:55) 'pk put' => https://perkeep.org/cmd/pk%20put (HTTP 404)

Errors. Checked 28018 links, 1615 destination URLs (206 ignored), 6 have errors, 1 has warning(s).

```

</p>
</details> 