### PR TITLE
Diskpacked max open files

### DIFF
--- a/pkg/blobserver/diskpacked/diskpacked_test.go
+++ b/pkg/blobserver/diskpacked/diskpacked_test.go
@@ -40,6 +40,10 @@ import (
 
 var ctxbg = context.Background()
 
+func init() {
+	debug = debugT(env.IsDebug())
+}
+
 func newTempDiskpacked(t *testing.T) blobserver.Storage {
 	return newTempDiskpackedWithIndex(t, jsonconfig.Obj{})
 }


### PR DESCRIPTION
Limit max open files in diskpacked blobserver.

It has opened (and kept open) all pack-%05d.blobs file.

With this change, an LRU cache is used with 80% of MaxFDs (or of 1024).