### PR TITLE
handle undefined image

### DIFF
--- a/server/perkeepd/ui/blob_item_image_content.js
+++ b/server/perkeepd/ui/blob_item_image_content.js
@@ -125,7 +125,7 @@ cam.BlobItemImageContent.getHandler = function(blobref, searchSession, href) {
 	var cci = cam.permanodeUtils.getSingleAttr(m.permanode, 'camliContentImage');
 	if (cci) {
 		var ccim = searchSession.getResolvedMeta(cci);
-		if (ccim) {
+		if (ccim && ccim.image) {
 			return new cam.BlobItemImageContent.Handler(ccim, href, searchSession.getTitle(blobref));
 		}
 	}


### PR DESCRIPTION
Some of the images I've loaded in have this attribute missing, which causes the home page to break. It could be an issue with webp images, i haven't investigated much. I'm loading them using `(*Client).UploadFile`. Jpegs seem to work fine. 