### PR TITLE
Implement kvClaimBytes to avoid allocation

### DIFF
--- a/pkg/index/corpus.go
+++ b/pkg/index/corpus.go
@@ -685,8 +685,7 @@ func (c *Corpus) mergeSignerKeyIdRow(k, v []byte) error {
 }
 
 func (c *Corpus) mergeClaimRow(k, v []byte) error {
-	// TODO: update kvClaim to take []byte instead of string
-	cl, ok := kvClaim(string(k), string(v), c.blobParse)
+	cl, ok := kvClaimBytes(k, v, c.blobParse)
 	if !ok || !cl.Permanode.Valid() {
 		return fmt.Errorf("bogus claim row: %q -> %q", k, v)
 	}
@@ -904,14 +903,14 @@ func (c *Corpus) mergeEXIFGPSRow(k, v []byte) error {
 // TODO: investigate / file bugs.
 const useBlobParseCache = false
 
-func (c *Corpus) blobParse(v string) (br blob.Ref, ok bool) {
+func (c *Corpus) blobParse(v []byte) (br blob.Ref, ok bool) {
 	if useBlobParseCache {
-		br, ok = c.brOfStr[v]
+		br, ok = c.brOfStr[string(v)]
 		if ok {
 			return
 		}
 	}
-	return blob.Parse(v)
+	return blob.ParseBytes(v)
 }
 
 // str returns s, interned.

--- a/pkg/index/index.go
+++ b/pkg/index/index.go
@@ -914,12 +914,16 @@ func (x *Index) AppendClaims(ctx context.Context, dst []camtypes.Claim, permaNod
 }
 
 func kvClaim(k, v string, blobParse func(string) (blob.Ref, bool)) (c camtypes.Claim, ok bool) {
+	const sep = "|"
 	const nKeyPart = 5
 	const nValPart = 4
+	if strings.Count(k, sep) < nKeyPart-1 || strings.Count(v, sep) < nValPart-1 {
+		return
+	}
 	var keya [nKeyPart]string
 	var vala [nValPart]string
-	keyPart := strutil.AppendSplitN(keya[:0], k, "|", -1)
-	valPart := strutil.AppendSplitN(vala[:0], v, "|", -1)
+	keyPart := strutil.AppendSplitN(keya[:0], k, sep, -1)
+	valPart := strutil.AppendSplitN(vala[:0], v, sep, -1)
 	if len(keyPart) < nKeyPart || len(valPart) < nValPart {
 		return
 	}
@@ -935,7 +939,7 @@ func kvClaim(k, v string, blobParse func(string) (blob.Ref, bool)) (c camtypes.C
 	if !ok {
 		return
 	}
-	date, err := time.Parse(time.RFC3339, keyPart[3])
+	date, err := time.Parse(time.RFC3339, string(keyPart[3]))
 	if err != nil {
 		return
 	}
@@ -947,6 +951,65 @@ func kvClaim(k, v string, blobParse func(string) (blob.Ref, bool)) (c camtypes.C
 		Type:      urld(valPart[0]),
 		Attr:      urld(valPart[1]),
 		Value:     urld(valPart[2]),
+	}, true
+}
+
+func kvClaimBytes(k, v []byte, blobParse func([]byte) (blob.Ref, bool)) (c camtypes.Claim, ok bool) {
+	sep := []byte{'|'}
+	const nKeyPart = 5
+	const nValPart = 4
+	if bytes.Count(k, sep) < nKeyPart-1 || bytes.Count(v, sep) < nValPart-1 {
+		return
+	}
+	var keya [nKeyPart][]byte
+	var vala [nValPart][]byte
+	appendSplitN := func(dst [][]byte, p, sep []byte, n int) [][]byte {
+		for {
+			pre, post, ok := bytes.Cut(p, sep)
+			if !ok {
+				dst = append(dst, p)
+				break
+			}
+			dst = append(dst, pre)
+			p = post
+		}
+		return dst
+	}
+	keyPart := appendSplitN(keya[:0], k, sep, -1)
+	valPart := appendSplitN(vala[:0], v, sep, -1)
+	if len(keyPart) < nKeyPart || len(valPart) < nValPart {
+		return
+	}
+	signerRef, ok := blobParse(valPart[3])
+	if !ok {
+		return
+	}
+	permaNode, ok := blobParse(keyPart[1])
+	if !ok {
+		return
+	}
+	claimRef, ok := blobParse(keyPart[4])
+	if !ok {
+		return
+	}
+	date, err := time.Parse(time.RFC3339, string(keyPart[3]))
+	if err != nil {
+		return
+	}
+	var buf strings.Builder
+	urldBytes := func(p []byte) string {
+		buf.Reset()
+		buf.Write(p)
+		return urld(buf.String())
+	}
+	return camtypes.Claim{
+		BlobRef:   claimRef,
+		Signer:    signerRef,
+		Permanode: permaNode,
+		Date:      date,
+		Type:      urldBytes(valPart[0]),
+		Attr:      urldBytes(valPart[1]),
+		Value:     urldBytes(valPart[2]),
 	}, true
 }
 


### PR DESCRIPTION
For a 4GiB RSS, this results ina mere 20MiB (0.80%) save.

So maybe just remove the TODO from the first line of kvClaims.

Showing nodes accounting for 63.16MB, 2.06% of 3059.31MB total Dropped 4 nodes (cum <= 15.30MB)
Showing top 10 nodes out of 162
      flat  flat%   sum%        cum   cum%
   48.72MB  1.59%  1.59%    48.72MB  1.59%  perkeep.org/pkg/index.(*Corpus).mergeBlobMeta
  -46.27MB  1.51%  0.08%   -11.75MB  0.38%  perkeep.org/pkg/index.(*Corpus).mergeClaimRow
   24.50MB   0.8%  0.88%    24.50MB   0.8%  strings.(*Builder).grow
      13MB  0.42%  1.31%       13MB  0.42%  strings.(*Builder).Write (inline)
   -9.50MB  0.31%     1%    -9.50MB  0.31%  perkeep.org/pkg/blob.sha1FromHexBytes
    8.63MB  0.28%  1.28%     8.63MB  0.28%  perkeep.org/pkg/index.attrValues.cacheAttrClaim (inline)
       8MB  0.26%  1.54%        8MB  0.26%  github.com/syndtr/goleveldb/leveldb/memdb.New
    6.50MB  0.21%  1.75%     6.50MB  0.21%  perkeep.org/pkg/blob.sha224FromHexBytes
    5.57MB  0.18%  1.93%     5.57MB  0.18%  github.com/syndtr/goleveldb/leveldb/util.(*BufferPool).Get
       4MB  0.13%  2.06%    12.63MB  0.41%  perkeep.org/pkg/index.(*PermanodeMeta).appendAttrClaim