### PR TITLE
doc/website: add 0.12 in release notes session and fix direct link in…

### DIFF
--- a/doc/geocoding.md
+++ b/doc/geocoding.md
@@ -11,4 +11,4 @@ Google and place it in your Perkeep configuration directory (run `pk env
 configdir` to find your configuration directory) in a file named
 `google-geocode.key`.
 
-To get the Google API key, see https://developers.google.com/maps/documentation/geocoding/get-api-key
+To get the Google API key, see [Set up the Geocoding API](https://developers.google.com/maps/documentation/geocoding/get-api-key).

--- a/website/content/download.md
+++ b/website/content/download.md
@@ -48,6 +48,7 @@ list](https://groups.google.com/group/camlistore).
 
 Previous release notes:
 
+-   [0.12 ("Toronto")](/doc/release/0.12), 2025-11-11
 -   [0.11 ("Seattle")](/doc/release/0.11), 2020-11-11
 -   [0.10 ("Bellingham")](/doc/release/0.10), 2018-05-02
 -   [2017-05-05](docs/release/monthly/2017-05-05.html)


### PR DESCRIPTION
Hi guys, Im new to the community. The newly released `0.12` is not included in [Release Notes in Download](https://perkeep.org/download) of the website.