### PR TITLE
all: run modernize

### DIFF
--- a/app/scanningcabinet/datastore.go
+++ b/app/scanningcabinet/datastore.go
@@ -786,8 +786,8 @@ func (np numberedPages) Less(i, j int) bool { return np[i].nb < np[j].nb }
 func (h *handler) describeDocument(b *search.DescribedBlob) (*document, error) {
 	var sortedPages numberedPages
 	for key, val := range b.Permanode.Attr {
-		if strings.HasPrefix(key, "camliPath:") {
-			pageNumber, err := strconv.ParseInt(strings.TrimPrefix(key, "camliPath:"), 10, 64)
+		if after, ok := strings.CutPrefix(key, "camliPath:"); ok {
+			pageNumber, err := strconv.ParseInt(after, 10, 64)
 			if err != nil {
 				return nil, fmt.Errorf("invalid page number %q in document %v: %w", key, b.BlobRef, err)
 			}

--- a/app/scanningcabinet/models.go
+++ b/app/scanningcabinet/models.go
@@ -92,7 +92,7 @@ func (mo *mediaObject) MakeViewModel() MediaObjectVM {
 // the same number of MediaObjectVMs with the data converted.
 func MakeMediaObjectViewModels(mediaObjects []mediaObject) []MediaObjectVM {
 	models := make([]MediaObjectVM, len(mediaObjects))
-	for i := 0; i < len(mediaObjects); i++ {
+	for i := range mediaObjects {
 		models[i] = mediaObjects[i].MakeViewModel()
 	}
 	return models
@@ -210,7 +210,7 @@ func (doc *document) MakeViewModel() DocumentVM {
 // the same number of DocumentVMs with the data converted.
 func MakeDocumentViewModels(docs []*document) []DocumentVM {
 	models := make([]DocumentVM, len(docs))
-	for i := 0; i < len(docs); i++ {
+	for i := range docs {
 		models[i] = docs[i].MakeViewModel()
 	}
 	return models

--- a/app/scanningcabinet/scancab/scancab.go
+++ b/app/scanningcabinet/scancab/scancab.go
@@ -171,7 +171,7 @@ func uploadOne(filename string) {
 		// not using RemoveAll on purpose, so that it does not remove if some of the temp files are still in there
 		os.Remove(tmpDir)
 	}()
-	for i := 0; i < cnt; i++ {
+	for i := range cnt {
 		fmt.Printf("	page %04d of %04d\n", i+1, cnt)
 		converted := path.Join(tmpDir, fmt.Sprintf("page-%04d.%v", i+1, ext))
 		pageArgs := append(args, fmt.Sprintf("%v[%d]", filename, i), converted)

--- a/cmd/pk-get/get.go
+++ b/cmd/pk-get/get.go
@@ -271,7 +271,7 @@ func smartFetch(ctx context.Context, src blob.Fetcher, targ string, br blob.Ref)
 		members := b.StaticSetMembers()
 		workc := make(chan work, len(members))
 		defer close(workc)
-		for i := 0; i < numWorkers; i++ {
+		for range numWorkers {
 			go func() {
 				for wi := range workc {
 					wi.errc <- smartFetch(ctx, src, targ, wi.br)

--- a/cmd/pk-put/blobs.go
+++ b/cmd/pk-put/blobs.go
@@ -127,8 +127,8 @@ func (c *blobCmd) RunCommand(args []string) error {
 			handleResult("claim-permanode-title", put, err)
 		}
 		if c.tag != "" {
-			tags := strings.Split(c.tag, ",")
-			for _, tag := range tags {
+			tags := strings.SplitSeq(c.tag, ",")
+			for tag := range tags {
 				m := schema.NewAddAttributeClaim(permaNode.BlobRef, "tag", tag)
 				put, err := up.UploadAndSignBlob(ctxbg, m)
 				handleResult("claim-permanode-tag", put, err)

--- a/cmd/pk-put/camput_test.go
+++ b/cmd/pk-put/camput_test.go
@@ -164,7 +164,7 @@ func TestUploadDirectories(t *testing.T) {
 		defer func() { testHookStatCache = nil }()
 
 		dirIter := uploadRoot
-		for i := 0; i < 2; i++ {
+		for range 2 {
 			dirPath := filepath.Join(dirIter, "dir")
 			mustMkdir(t, dirPath, 0700)
 			for _, baseFile := range []string{"file.txt", "FILE.txt"} {

--- a/cmd/pk-put/files.go
+++ b/cmd/pk-put/files.go
@@ -278,8 +278,8 @@ func (c *fileCmd) RunCommand(args []string) error {
 			handleResult("claim-permanode-title", put, err)
 		}
 		if c.tag != "" {
-			tags := strings.Split(c.tag, ",")
-			for _, tag := range tags {
+			tags := strings.SplitSeq(c.tag, ",")
+			for tag := range tags {
 				m := schema.NewAddAttributeClaim(permaNode.BlobRef, "tag", tag)
 				put, err := up.UploadAndSignBlob(ctxbg, m)
 				handleResult("claim-permanode-tag", put, err)

--- a/cmd/pk-put/permanode.go
+++ b/cmd/pk-put/permanode.go
@@ -94,8 +94,8 @@ func (c *permanodeCmd) RunCommand(args []string) error {
 		handleResult("claim-permanode-title", put, err)
 	}
 	if c.tag != "" {
-		tags := strings.Split(c.tag, ",")
-		for _, tag := range tags {
+		tags := strings.SplitSeq(c.tag, ",")
+		for tag := range tags {
 			m := schema.NewAddAttributeClaim(permaNode.BlobRef, "tag", tag)
 			put, err := up.UploadAndSignBlob(ctxbg, m)
 			handleResult("claim-permanode-tag", put, err)

--- a/cmd/pk-put/rawobj.go
+++ b/cmd/pk-put/rawobj.go
@@ -61,7 +61,7 @@ func (c *rawCmd) RunCommand(args []string) error {
 	}
 
 	bb := schema.NewBuilder()
-	for _, kv := range strings.Split(c.vals, "|") {
+	for kv := range strings.SplitSeq(c.vals, "|") {
 		kv := strings.SplitN(kv, "=", 2)
 		bb.SetRawStringField(kv[0], kv[1])
 	}

--- a/cmd/pk/sync.go
+++ b/cmd/pk/sync.go
@@ -428,7 +428,6 @@ func (c *syncCmd) doPass(src, dest, thirdLeg blobserver.Storage) (stats SyncStat
 	var wg sync.WaitGroup
 
 	for sb := range syncBlobs {
-		sb := sb
 		gate.Start()
 		wg.Add(1)
 		go func() {

--- a/dev/envvardoc/envvardoc.go
+++ b/dev/envvardoc/envvardoc.go
@@ -182,7 +182,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	for _, dn := range strings.Split(*srcDirs, ",") {
+	for dn := range strings.SplitSeq(*srcDirs, ",") {
 		err := filepath.Walk(dn, ec.walk)
 		if err != nil {
 			log.Fatal(err)

--- a/internal/azure/storage/client.go
+++ b/internal/azure/storage/client.go
@@ -206,10 +206,7 @@ func (c *Client) ListBlobs(ctx context.Context, container string, maxResults int
 	}
 	marker := ""
 	for len(blobs) < maxResults {
-		fetchN := maxResults - len(blobs)
-		if fetchN > maxList {
-			fetchN = maxList
-		}
+		fetchN := min(maxResults-len(blobs), maxList)
 		var bres listBlobsResults
 
 		listURL := fmt.Sprintf("%s?restype=container&comp=list&marker=%s&maxresults=%d",

--- a/internal/chanworker/chanworker.go
+++ b/internal/chanworker/chanworker.go
@@ -70,11 +70,11 @@ func NewWorker(nWorkers int, fn func(el interface{}, ok bool)) chan<- interface{
 		buf:   list.New(),
 	}
 	go w.pump()
-	for i := 0; i < nWorkers; i++ {
+	for range nWorkers {
 		go w.work()
 	}
 	go func() {
-		for i := 0; i < nWorkers; i++ {
+		for range nWorkers {
 			<-w.donec
 		}
 		fn(nil, false) // final sentinel

--- a/internal/images/bench_test.go
+++ b/internal/images/bench_test.go
@@ -29,8 +29,8 @@ func benchRescale(b *testing.B, w, h, thumbW, thumbH int) {
 	if !needRescale {
 		b.Fatal("opts.rescaleDimensions failed to indicate image needs rescale")
 	}
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+
+	for b.Loop() {
 		_ = rescale(im, sw, sh)
 	}
 }

--- a/internal/images/benchfastjpeg_test.go
+++ b/internal/images/benchfastjpeg_test.go
@@ -110,7 +110,7 @@ func testRun(b testing.TB, decode decodeFunc) {
 }
 
 func common(b *testing.B, decode decodeFunc) {
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		testRun(b, decode)
 	}
 }

--- a/internal/images/images.go
+++ b/internal/images/images.go
@@ -163,24 +163,24 @@ func rotate(im image.Image, angle int) image.Image {
 	case 90:
 		newH, newW := im.Bounds().Dx(), im.Bounds().Dy()
 		rotated = image.NewNRGBA(image.Rect(0, 0, newW, newH))
-		for y := 0; y < newH; y++ {
-			for x := 0; x < newW; x++ {
+		for y := range newH {
+			for x := range newW {
 				rotated.Set(x, y, im.At(newH-1-y, x))
 			}
 		}
 	case -90:
 		newH, newW := im.Bounds().Dx(), im.Bounds().Dy()
 		rotated = image.NewNRGBA(image.Rect(0, 0, newW, newH))
-		for y := 0; y < newH; y++ {
-			for x := 0; x < newW; x++ {
+		for y := range newH {
+			for x := range newW {
 				rotated.Set(x, y, im.At(y, newW-1-x))
 			}
 		}
 	case 180, -180:
 		newW, newH := im.Bounds().Dx(), im.Bounds().Dy()
 		rotated = image.NewNRGBA(image.Rect(0, 0, newW, newH))
-		for y := 0; y < newH; y++ {
-			for x := 0; x < newW; x++ {
+		for y := range newH {
+			for x := range newW {
 				rotated.Set(x, y, im.At(newW-1-x, newH-1-y))
 			}
 		}
@@ -217,7 +217,7 @@ func flip(im image.Image, dir FlipDirection) image.Image {
 		}
 	}
 	if dir&FlipHorizontal != 0 {
-		for y := 0; y < dy; y++ {
+		for y := range dy {
 			for x := 0; x < dx/2; x++ {
 				old := im.At(x, y)
 				di.Set(x, y, im.At(dx-1-x, y))
@@ -227,7 +227,7 @@ func flip(im image.Image, dir FlipDirection) image.Image {
 	}
 	if dir&FlipVertical != 0 {
 		for y := 0; y < dy/2; y++ {
-			for x := 0; x < dx; x++ {
+			for x := range dx {
 				old := im.At(x, y)
 				di.Set(x, y, im.At(x, dy-1-y))
 				di.Set(x, dy-1-y, old)

--- a/internal/images/resize/bench_test.go
+++ b/internal/images/resize/bench_test.go
@@ -32,32 +32,32 @@ func halve(m image.Image) {
 
 func BenchmarkResizeRGBA(b *testing.B) {
 	m := image.NewRGBA(orig)
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+
+	for b.Loop() {
 		resize(m)
 	}
 }
 
 func BenchmarkHalveRGBA(b *testing.B) {
 	m := image.NewRGBA(orig)
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+
+	for b.Loop() {
 		halve(m)
 	}
 }
 
 func BenchmarkResizeYCrCb(b *testing.B) {
 	m := image.NewYCbCr(orig, image.YCbCrSubsampleRatio422)
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+
+	for b.Loop() {
 		resize(m)
 	}
 }
 
 func BenchmarkHalveYCrCb(b *testing.B) {
 	m := image.NewYCbCr(orig, image.YCbCrSubsampleRatio422)
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+
+	for b.Loop() {
 		halve(m)
 	}
 }

--- a/internal/images/resize/resize.go
+++ b/internal/images/resize/resize.go
@@ -72,18 +72,12 @@ func Resize(m image.Image, r image.Rectangle, w, h int) image.Image {
 			// Spread the source pixel over 1 or more destination rows.
 			py := uint64(y-r.Min.Y) * hh
 			for remy := hh; remy > 0; {
-				qy := dy - (py % dy)
-				if qy > remy {
-					qy = remy
-				}
+				qy := min(dy-(py%dy), remy)
 				// Spread the source pixel over 1 or more destination columns.
 				px := uint64(x-r.Min.X) * ww
 				index := 4 * ((py/dy)*ww + (px / dx))
 				for remx := ww; remx > 0; {
-					qx := dx - (px % dx)
-					if qx > remx {
-						qx = remx
-					}
+					qx := min(dx-(px%dx), remx)
 					sum[index+0] += r64 * qx * qy
 					sum[index+1] += g64 * qx * qy
 					sum[index+2] += b64 * qx * qy
@@ -103,8 +97,8 @@ func Resize(m image.Image, r image.Rectangle, w, h int) image.Image {
 // average convert the sums to averages and returns the result.
 func average(sum []uint64, w, h int, n uint64) image.Image {
 	ret := image.NewRGBA(image.Rect(0, 0, w, h))
-	for y := 0; y < h; y++ {
-		for x := 0; x < w; x++ {
+	for y := range h {
+		for x := range w {
 			i := y*ret.Stride + x*4
 			j := 4 * (y*w + x)
 			ret.Pix[i+0] = uint8(sum[j+0] / n)
@@ -144,18 +138,12 @@ func resizeRGBA(m *image.RGBA, r image.Rectangle, w, h int) image.Image {
 			// Spread the source pixel over 1 or more destination rows.
 			py := uint64(y-r.Min.Y) * hh
 			for remy := hh; remy > 0; {
-				qy := dy - (py % dy)
-				if qy > remy {
-					qy = remy
-				}
+				qy := min(dy-(py%dy), remy)
 				// Spread the source pixel over 1 or more destination columns.
 				px := uint64(x-r.Min.X) * ww
 				index := 4 * ((py/dy)*ww + (px / dx))
 				for remx := ww; remx > 0; {
-					qx := dx - (px % dx)
-					if qx > remx {
-						qx = remx
-					}
+					qx := min(dx-(px%dx), remx)
 					qxy := qx * qy
 					sum[index+0] += r64 * qxy
 					sum[index+1] += g64 * qxy
@@ -304,8 +292,8 @@ func Resample(m image.Image, r image.Rectangle, w, h int) image.Image {
 	img := image.NewRGBA(image.Rect(0, 0, w, h))
 	xStep := float64(r.Dx()) / float64(w)
 	yStep := float64(r.Dy()) / float64(h)
-	for y := 0; y < h; y++ {
-		for x := 0; x < w; x++ {
+	for y := range h {
+		for x := range w {
 			xSrc := int(float64(r.Min.X) + float64(x)*xStep)
 			ySrc := int(float64(r.Min.Y) + float64(y)*yStep)
 			r, g, b, a := m.At(xSrc, ySrc).RGBA()

--- a/internal/netutil/netutil_test.go
+++ b/internal/netutil/netutil_test.go
@@ -184,7 +184,7 @@ func TestListenOnLocalRandomPort(t *testing.T) {
 }
 
 func BenchmarkLocalhostLookup(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		if ip := localhostLookup(); ip == nil {
 			b.Fatal("no ip found.")
 		}
@@ -192,7 +192,7 @@ func BenchmarkLocalhostLookup(b *testing.B) {
 }
 
 func BenchmarkLoopbackIP(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		if ip := loopbackIP(); ip == nil {
 			b.Fatal("no ip found.")
 		}

--- a/pkg/blob/ref_test.go
+++ b/pkg/blob/ref_test.go
@@ -220,7 +220,7 @@ func BenchmarkParseBlob(b *testing.B) {
 	b.ReportAllocs()
 	ref := "sha1-0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33"
 	refb := []byte(ref)
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		if _, ok := Parse(ref); !ok {
 			b.FailNow()
 		}
@@ -330,7 +330,7 @@ func TestEqualString(t *testing.T) {
 
 func BenchmarkEqualString(b *testing.B) {
 	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		for _, tt := range equalStringTests {
 			got := tt.ref.EqualString(tt.str)
 			if got != tt.want {
@@ -396,7 +396,7 @@ func TestHasPrefix(t *testing.T) {
 
 func BenchmarkHasPrefix(b *testing.B) {
 	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		for _, tt := range hasPrefixTests {
 			got := tt.ref.HasPrefix(tt.str)
 			if got != tt.want {

--- a/pkg/blobserver/azure/remove.go
+++ b/pkg/blobserver/azure/remove.go
@@ -32,7 +32,6 @@ func (sto *azureStorage) RemoveBlobs(ctx context.Context, blobs []blob.Ref) erro
 	var wg syncutil.Group
 
 	for _, blob := range blobs {
-		blob := blob
 		removeGate.Start()
 		wg.Go(func() error {
 			defer removeGate.Done()

--- a/pkg/blobserver/blobhub.go
+++ b/pkg/blobserver/blobhub.go
@@ -137,13 +137,11 @@ func (h *memHub) NotifyBlobReceived(sb blob.SizedRef) error {
 
 	// Global listeners
 	for ch := range h.listeners {
-		ch := ch
 		go func() { ch <- br }()
 	}
 
 	// Blob-specific listeners
 	for ch := range h.blobListeners[br] {
-		ch := ch
 		go func() { ch <- br }()
 	}
 	return nil

--- a/pkg/blobserver/blobpacked/blobpacked.go
+++ b/pkg/blobserver/blobpacked/blobpacked.go
@@ -1020,7 +1020,6 @@ func (s *storage) RemoveBlobs(ctx context.Context, blobs []blob.Ref) error {
 	var grp syncutil.Group
 	delGate := syncutil.NewGate(removeLookups)
 	for _, br := range blobs {
-		br := br
 		delGate.Start()
 		grp.Go(func() error {
 			defer delGate.Done()

--- a/pkg/blobserver/blobpacked/stream_test.go
+++ b/pkg/blobserver/blobpacked/stream_test.go
@@ -43,7 +43,7 @@ func TestStreamBlobs(t *testing.T) {
 
 	all := map[blob.Ref]bool{}
 	const nBlobs = 10
-	for i := 0; i < nBlobs; i++ {
+	for i := range nBlobs {
 		b := &test.Blob{Contents: strconv.Itoa(i)}
 		b.MustUpload(t, small)
 		all[b.BlobRef()] = true
@@ -130,7 +130,7 @@ func testStreamBlobs(t *testing.T,
 
 func populateLoose(t *testing.T, s *storage) (wants []storagetest.StreamerTestOpt) {
 	const nBlobs = 10
-	for i := 0; i < nBlobs; i++ {
+	for i := range nBlobs {
 		(&test.Blob{Contents: strconv.Itoa(i)}).MustUpload(t, s)
 	}
 	return append(wants, storagetest.WantN(nBlobs))

--- a/pkg/blobserver/diskpacked/dele.go
+++ b/pkg/blobserver/diskpacked/dele.go
@@ -65,7 +65,7 @@ func (s *storage) delete(br blob.Ref) error {
 	if space < 0 {
 		return fmt.Errorf("delete: cannot find space in header %q", b)
 	}
-	for i := 0; i < dash; i++ {
+	for i := range dash {
 		b[i] = 'x'
 	}
 	for i := dash + 1; i < dash+1+space; i++ {

--- a/pkg/blobserver/diskpacked/diskpacked.go
+++ b/pkg/blobserver/diskpacked/diskpacked.go
@@ -422,7 +422,6 @@ func (s *storage) RemoveBlobs(ctx context.Context, blobs []blob.Ref) error {
 	batch := s.index.BeginBatch()
 	var wg syncutil.Group
 	for _, br := range blobs {
-		br := br
 		removeGate.Start()
 		batch.Delete(br.String())
 		wg.Go(func() error {

--- a/pkg/blobserver/encrypt/encrypt_test.go
+++ b/pkg/blobserver/encrypt/encrypt_test.go
@@ -181,7 +181,7 @@ func TestEncryptStress(t *testing.T) {
 	blobs := make(chan string, workers)
 	defer close(blobs)
 
-	for i := 0; i < workers; i++ {
+	for range workers {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
@@ -195,7 +195,7 @@ func TestEncryptStress(t *testing.T) {
 		}()
 	}
 
-	for i := 0; i < numBlobs; i++ {
+	for i := range numBlobs {
 		blobs <- fmt.Sprintf("%d", i)
 	}
 }

--- a/pkg/blobserver/files/enumerate.go
+++ b/pkg/blobserver/files/enumerate.go
@@ -120,10 +120,7 @@ func (ds *Storage) readBlobs(ctx context.Context, opts readBlobRequest) error {
 				newBlobPrefix = opts.blobPrefix + name
 			}
 			if len(opts.after) > 0 {
-				compareLen := len(newBlobPrefix)
-				if len(opts.after) < compareLen {
-					compareLen = len(opts.after)
-				}
+				compareLen := min(len(opts.after), len(newBlobPrefix))
 				if newBlobPrefix[:compareLen] < opts.after[:compareLen] {
 					continue
 				}

--- a/pkg/blobserver/files/enumerate_test.go
+++ b/pkg/blobserver/files/enumerate_test.go
@@ -133,7 +133,7 @@ func TestEnumerateIsSorted(t *testing.T) {
 
 	const blobsToMake = 250
 	t.Logf("Uploading test blobs...")
-	for i := 0; i < blobsToMake; i++ {
+	for i := range blobsToMake {
 		blob := &test.Blob{Contents: fmt.Sprintf("blob-%d", i)}
 		blob.MustUpload(t, ds)
 	}

--- a/pkg/blobserver/localdisk/localdisk_test.go
+++ b/pkg/blobserver/localdisk/localdisk_test.go
@@ -104,7 +104,7 @@ func TestMultiStat(t *testing.T) {
 	// maxParallelStats other dummy blobs, to exercise the stat
 	// rate-limiting (which had a deadlock once after a cleanup)
 	const maxParallelStats = 20
-	for i := 0; i < maxParallelStats; i++ {
+	for i := range maxParallelStats {
 		blobs = append(blobs, blob.RefFromString(strconv.Itoa(i)))
 	}
 

--- a/pkg/blobserver/mergedenum.go
+++ b/pkg/blobserver/mergedenum.go
@@ -58,7 +58,7 @@ func mergedEnumerate(ctx context.Context, dest chan<- blob.SizedRef, nsrc int, g
 	}
 
 	peekers := make([]*blob.ChanPeeker, 0, nsrc)
-	for i := 0; i < nsrc; i++ {
+	for i := range nsrc {
 		peekers = append(peekers, startEnum(getSource(i)))
 	}
 

--- a/pkg/blobserver/mergedenum_test.go
+++ b/pkg/blobserver/mergedenum_test.go
@@ -140,7 +140,7 @@ func enumBlobRange(base string, start, count int) BlobEnumerator {
 
 func strRange(base string, start, count int) []string {
 	v := make([]string, count)
-	for i := 0; i < count; i++ {
+	for i := range count {
 		v[i] = fmt.Sprintf("%s-%04d", base, start+i)
 	}
 	return v

--- a/pkg/blobserver/mongo/remove.go
+++ b/pkg/blobserver/mongo/remove.go
@@ -33,7 +33,6 @@ func (m *mongoStorage) RemoveBlobs(ctx context.Context, blobs []blob.Ref) error 
 	var wg syncutil.Group
 
 	for _, blob := range blobs {
-		blob := blob
 		removeGate.Start()
 		wg.Go(func() error {
 			defer removeGate.Done()

--- a/pkg/blobserver/multistream_test.go
+++ b/pkg/blobserver/multistream_test.go
@@ -56,7 +56,7 @@ func (s staticStreamer) StreamBlobs(ctx context.Context, dest chan<- blobserver.
 func TestStaticStreamer(t *testing.T) {
 	var blobs []*blob.Blob
 	var want []blob.SizedRef
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		tb := &test.Blob{Contents: strconv.Itoa(i)}
 		b := tb.Blob()
 		blobs = append(blobs, b)
@@ -71,9 +71,9 @@ func TestMultiStreamer(t *testing.T) {
 	var want []blob.SizedRef
 	n := 0
 
-	for st := 0; st < 3; st++ {
+	for range 3 {
 		var blobs []*blob.Blob
-		for i := 0; i < 3; i++ {
+		for range 3 {
 			n++
 			tb := &test.Blob{Contents: strconv.Itoa(n)}
 			b := tb.Blob()

--- a/pkg/blobserver/replica/replica.go
+++ b/pkg/blobserver/replica/replica.go
@@ -159,7 +159,6 @@ func (sto *replicaStorage) StatBlobs(ctx context.Context, blobs []blob.Ref, fn f
 	group, ctx := errgroup.WithContext(ctx)
 
 	for _, replica := range sto.readReplicas {
-		replica := replica
 		group.Go(func() error {
 			return replica.StatBlobs(ctx, blobs, func(sb blob.SizedRef) error {
 				mu.Lock()

--- a/pkg/blobserver/sftp/sftp.go
+++ b/pkg/blobserver/sftp/sftp.go
@@ -234,8 +234,8 @@ func (s *Storage) dialSFTP() (sc *sftp.Client, waiter func() error, toClose io.C
 	// Another special case for testing:
 	user := s.cc.User
 	const sysPrefix = "use-system-ssh:"
-	if strings.HasPrefix(user, sysPrefix) {
-		user = strings.TrimPrefix(user, sysPrefix)
+	if after, ok := strings.CutPrefix(user, sysPrefix); ok {
+		user = after
 		cmd := exec.Command("ssh", user+"@"+strings.TrimSuffix(s.addr, ":22"), "-s", "sftp")
 		cmd.Stderr = os.Stderr
 		// get stdin and stdout
@@ -391,7 +391,7 @@ func (s sftpFS) TempFile(dir, prefix string) (files.WritableFile, error) {
 		return nil, err
 	}
 	dir = filepath.ToSlash(dir)
-	for tries := 0; tries < 5; tries++ {
+	for range 5 {
 		sufRand := make([]byte, 5)
 		_, _ = rand.Read(sufRand)
 		suffix := fmt.Sprintf("%x", sufRand)

--- a/pkg/blobserver/storagetest/storagetest.go
+++ b/pkg/blobserver/storagetest/storagetest.go
@@ -82,7 +82,7 @@ func TestOpt(t *testing.T, opt Opts) {
 
 	contents := []string{"foo", "quux", "asdf", "qwerty", "0123456789"}
 	if !testing.Short() {
-		for i := 0; i < 95; i++ {
+		for i := range 95 {
 			contents = append(contents, "foo-"+strconv.Itoa(i))
 		}
 	}
@@ -510,7 +510,7 @@ func TestStreamer(t *testing.T, bs blobserver.BlobStreamer, opts ...StreamerTest
 	sawStreamed = map[blob.Ref]int{}
 	gotRefs = gotRefs[:0]
 	contToken := ""
-	for i := 0; i < len(wantRefs); i++ {
+	for i := range wantRefs {
 		ctx, cancel := context.WithCancel(context.TODO())
 		defer cancel()
 		ch := make(chan blobserver.BlobAndToken)

--- a/pkg/blobserver/sync_test.go
+++ b/pkg/blobserver/sync_test.go
@@ -63,7 +63,7 @@ func sendTestBlobs(ch chan blob.SizedRef, list string, size uint32) {
 	if list == "" {
 		return
 	}
-	for _, br := range strings.Split(list, ",") {
+	for br := range strings.SplitSeq(list, ",") {
 		ch <- blob.SizedRef{Ref: blob.MustParse(br), Size: size}
 	}
 }

--- a/pkg/blobserver/union/union.go
+++ b/pkg/blobserver/union/union.go
@@ -73,7 +73,6 @@ func (sto *unionStorage) Fetch(ctx context.Context, b blob.Ref) (file io.ReadClo
 	results := make(chan result, len(sto.subsets))
 	var wg sync.WaitGroup
 	for _, bs := range sto.subsets {
-		bs := bs
 		wg.Add(1)
 		go func() {
 			defer wg.Done()

--- a/pkg/client/android/androidx.go
+++ b/pkg/client/android/androidx.go
@@ -338,10 +338,7 @@ type writeUntilSliceFull struct {
 func (w writeUntilSliceFull) Write(p []byte) (n int, err error) {
 	s := *w.s
 	l := len(s)
-	growBy := cap(s) - l
-	if growBy > len(p) {
-		growBy = len(p)
-	}
+	growBy := min(cap(s)-l, len(p))
 	s = s[0 : l+growBy]
 	copy(s[l:], p)
 	*w.s = s

--- a/pkg/client/config.go
+++ b/pkg/client/config.go
@@ -513,14 +513,12 @@ func newIgnoreChecker(ignoredFiles []string) func(path string) (shouldIgnore boo
 	// 3) absolute paths
 	// 4) paths components
 	for _, pattern := range ignFiles {
-		pattern := pattern
 		_, err := filepath.Match(pattern, "whatever")
 		if err == nil {
 			fns = append(fns, func(v string) bool { return isShellPatternMatch(pattern, v) })
 		}
 	}
 	for _, pattern := range ignFiles {
-		pattern := pattern
 		if filepath.IsAbs(pattern) {
 			fns = append(fns, func(v string) bool { return hasDirPrefix(filepath.Clean(pattern), v) })
 		} else {

--- a/pkg/importer/picasa/testdata.go
+++ b/pkg/importer/picasa/testdata.go
@@ -100,10 +100,7 @@ func fakeAlbumsList(index, nTotal, nEntries int, cached map[int]string) string {
 		return cl
 	}
 
-	max := index + nEntries
-	if max > nTotal+1 {
-		max = nTotal + 1
-	}
+	max := min(index+nEntries, nTotal+1)
 	var entries []picago.Entry
 	for i := index; i < max; i++ {
 		entries = append(entries, fakeAlbum(i))
@@ -149,10 +146,7 @@ func fakeAlbum(counter int) picago.Entry {
 // index, and ends at index + nEntries (exclusive), or at nTotal (inclusive),
 // whichever is the lowest.
 func fakePhotosList(index, nTotal, nEntries int) string {
-	max := index + nEntries
-	if max > nTotal+1 {
-		max = nTotal + 1
-	}
+	max := min(index+nEntries, nTotal+1)
 	var entries []picago.Entry
 	for i := index; i < max; i++ {
 		entries = append(entries, fakePhotoEntry(i, nTotal))

--- a/pkg/importer/swarm/testdata.go
+++ b/pkg/importer/swarm/testdata.go
@@ -154,10 +154,7 @@ func fakeCheckinsList(offset, maxCheckin int, towns map[int]*venueLocationItem, 
 	if cl, ok := cached[offset]; ok {
 		return cl
 	}
-	max := offset + checkinsRequestLimit
-	if max > maxCheckin {
-		max = maxCheckin
-	}
+	max := min(offset+checkinsRequestLimit, maxCheckin)
 	var items []*checkinItem
 	tzCounter := 0
 	venueCounter := 0

--- a/pkg/importer/twitter/testdata.go
+++ b/pkg/importer/twitter/testdata.go
@@ -94,10 +94,7 @@ func fakeTimeLine(maxId, minId int64, cached map[int64]string) string {
 	if tl, ok := cached[maxId]; ok {
 		return tl
 	}
-	min := maxId - int64(tweetRequestLimit)
-	if min <= minId {
-		min = minId
-	}
+	min := max(maxId-int64(tweetRequestLimit), minId)
 	var tweets []*apiTweetItem
 	entitiesCounter := 0
 	geoCounter := 0

--- a/pkg/index/corpus_bench_test.go
+++ b/pkg/index/corpus_bench_test.go
@@ -43,7 +43,7 @@ func BenchmarkCorpusFromStorage(b *testing.B) {
 		}
 		id := indextest.NewIndexDeps(idx)
 		id.Fataler = b
-		for i := 0; i < 10; i++ {
+		for i := range 10 {
 			fileRef, _ := id.UploadFile("file.txt", fmt.Sprintf("some file %d", i), time.Unix(1382073153, 0))
 			pn := id.NewPlannedPermanode(fmt.Sprint(i))
 			id.SetAttribute(pn, "camliContent", fileRef.String())
@@ -52,9 +52,7 @@ func BenchmarkCorpusFromStorage(b *testing.B) {
 	defer index.SetVerboseCorpusLogging(true)
 	index.SetVerboseCorpusLogging(false)
 
-	b.ResetTimer()
-
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, err := index.NewCorpusFromStorage(kvForBenchmark)
 		if err != nil {
 			b.Fatal(err)

--- a/pkg/index/corpus_test.go
+++ b/pkg/index/corpus_test.go
@@ -514,7 +514,7 @@ func testCacheSortedPermanodesRace(t *testing.T,
 	}
 	donec := make(chan struct{})
 	go func() {
-		for i := 0; i < 100; i++ {
+		for i := range 100 {
 			nth := fmt.Sprintf("%d", i)
 			// No need to lock the index here. It is already done within NewPlannedPermanode,
 			// because it calls idxd.Index.ReceiveBlob.
@@ -524,7 +524,7 @@ func testCacheSortedPermanodesRace(t *testing.T,
 		donec <- struct{}{}
 	}()
 	go func() {
-		for i := 0; i < 10; i++ {
+		for range 10 {
 			idx.RLock()
 			enumFunc(c, func(m camtypes.BlobMeta) bool {
 				return true

--- a/pkg/index/index.go
+++ b/pkg/index/index.go
@@ -1790,7 +1790,7 @@ var camliTypeMIMEPrefixBytes = []byte(camliTypeMIMEPrefix)
 // "application/json; camliType=file" => "file"
 // "image/gif" => ""
 func camliTypeFromMIME(mime string) schema.CamliType {
-	if v := strings.TrimPrefix(mime, camliTypeMIMEPrefix); v != mime {
+	if v, ok := strings.CutPrefix(mime, camliTypeMIMEPrefix); ok {
 		return schema.CamliType(v)
 	}
 	return ""

--- a/pkg/index/sniff.go
+++ b/pkg/index/sniff.go
@@ -52,10 +52,7 @@ func (sn *BlobSniffer) Write(d []byte) (int, error) {
 	}
 	sn.written += int64(len(d))
 	if len(sn.contents) < schema.MaxSchemaBlobSize {
-		n := schema.MaxSchemaBlobSize - len(sn.contents)
-		if len(d) < n {
-			n = len(d)
-		}
+		n := min(len(d), schema.MaxSchemaBlobSize-len(sn.contents))
 		sn.contents = append(sn.contents, d[:n]...)
 	}
 	return len(d), nil

--- a/pkg/index/sqlite/sqlite_test.go
+++ b/pkg/index/sqlite/sqlite_test.go
@@ -109,7 +109,7 @@ func TestConcurrency(t *testing.T) {
 	defer clean()
 	const n = 100
 	ch := make(chan error)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		i := i
 		go func() {
 			bm := s.BeginBatch()
@@ -118,7 +118,7 @@ func TestConcurrency(t *testing.T) {
 			ch <- s.CommitBatch(bm)
 		}()
 	}
-	for i := 0; i < n; i++ {
+	for i := range n {
 		if err := <-ch; err != nil {
 			t.Errorf("%d: %v", i, err)
 		}
@@ -149,13 +149,13 @@ func TestFDLeak(t *testing.T) {
 
 	bm := s.BeginBatch()
 	const numRows = 150 // 3x the batchSize of 50 in sqlindex.go; to guarantee we do multiple batches
-	for i := 0; i < numRows; i++ {
+	for i := range numRows {
 		bm.Set(fmt.Sprintf("key:%05d", i), fmt.Sprint(i))
 	}
 	if err := s.CommitBatch(bm); err != nil {
 		t.Fatal(err)
 	}
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		it := s.Find("key:", "key~")
 		n := 0
 		for it.Next() {

--- a/pkg/jsonsign/sign_normal.go
+++ b/pkg/jsonsign/sign_normal.go
@@ -44,7 +44,7 @@ func (fe *FileEntityFetcher) decryptEntity(e *openpgp.Entity) error {
 			Prompt:   "Passphrase",
 			Desc:     desc,
 		}
-		for tries := 0; tries < 2; tries++ {
+		for range 2 {
 			pass, err := conn.GetPassphrase(req)
 			if err == nil {
 				err = e.PrivateKey.Decrypt([]byte(pass))
@@ -65,7 +65,7 @@ func (fe *FileEntityFetcher) decryptEntity(e *openpgp.Entity) error {
 	}
 
 	pinReq := &pinentry.Request{Desc: desc, Prompt: "Passphrase"}
-	for tries := 0; tries < 2; tries++ {
+	for range 2 {
 		pass, err := pinReq.GetPIN()
 		if err == nil {
 			err = e.PrivateKey.Decrypt([]byte(pass))

--- a/pkg/jsonsign/verify.go
+++ b/pkg/jsonsign/verify.go
@@ -48,10 +48,7 @@ func reArmor(line string) string {
 	payload := line[0:lastEq]
 	crc := line[lastEq:]
 	for len(payload) > 0 {
-		chunkLen := len(payload)
-		if chunkLen > 60 {
-			chunkLen = 60
-		}
+		chunkLen := min(len(payload), 60)
 		fmt.Fprintf(buf, "%s\n", payload[0:chunkLen])
 		payload = payload[chunkLen:]
 	}

--- a/pkg/schema/fileread_test.go
+++ b/pkg/schema/fileread_test.go
@@ -438,10 +438,7 @@ type summary []byte
 
 func (s summary) String() string {
 	const prefix = 10
-	plen := prefix
-	if len(s) < plen {
-		plen = len(s)
-	}
+	plen := min(len(s), prefix)
 	return fmt.Sprintf("%d bytes, starting with %q", len(s), []byte(s[:plen]))
 }
 

--- a/pkg/schema/filewriter.go
+++ b/pkg/schema/filewriter.go
@@ -398,7 +398,7 @@ func writeFileChunks(ctx context.Context, bs blobserver.StatReceiver, file *Buil
 	// see if any generated errors.
 	// Once this loop is done, we own all the tokens in gatec, so nobody
 	// else can have one outstanding.
-	for i := 0; i < chunksInFlight; i++ {
+	for range chunksInFlight {
 		gatec.Start()
 	}
 	select {

--- a/pkg/search/describe.go
+++ b/pkg/search/describe.go
@@ -919,7 +919,7 @@ func (dr *DescribeRequest) describeRefs(ctx context.Context, str string, depth i
 }
 
 func (b *DescribedBlob) setMIMEType(mime string) {
-	if strings.HasPrefix(mime, camliTypePrefix) {
-		b.CamliType = schema.CamliType(strings.TrimPrefix(mime, camliTypePrefix))
+	if after0, ok := strings.CutPrefix(mime, camliTypePrefix); ok {
+		b.CamliType = schema.CamliType(after0)
 	}
 }

--- a/pkg/search/describe_test.go
+++ b/pkg/search/describe_test.go
@@ -412,7 +412,7 @@ func TestDescribeRace(t *testing.T) {
 	<-headstartc
 	ctx := context.Background()
 	go func() {
-		for i := 0; i < headstart; i++ {
+		for i := range headstart {
 			br := blobrefs[i]
 			res, err := h.Describe(ctx, &search.DescribeRequest{
 				BlobRef: br,

--- a/pkg/search/query.go
+++ b/pkg/search/query.go
@@ -1059,10 +1059,7 @@ func (h *Handler) Query(ctx context.Context, rawq *SearchQuery) (ret_ *SearchRes
 					// If Limit is even, and the number of results before and after Around
 					// are both greater than half the limit, then there will be one more result before
 					// than after.
-					discard := len(res.Blobs) - q.Limit/2 - 1
-					if discard < 0 {
-						discard = 0
-					}
+					discard := max(len(res.Blobs)-q.Limit/2-1, 0)
 					res.Blobs = res.Blobs[discard:]
 				}
 				if len(res.Blobs) == q.Limit {
@@ -1140,14 +1137,8 @@ func (h *Handler) Query(ctx context.Context, rawq *SearchQuery) (ret_ *SearchRes
 					if aroundPos == len(res.Blobs) || res.Blobs[aroundPos].Blob != q.Around {
 						panic("q.Around blobRef should be in the results")
 					}
-					lowerBound := aroundPos - q.Limit/2
-					if lowerBound < 0 {
-						lowerBound = 0
-					}
-					upperBound := lowerBound + q.Limit
-					if upperBound > len(res.Blobs) {
-						upperBound = len(res.Blobs)
-					}
+					lowerBound := max(aroundPos-q.Limit/2, 0)
+					upperBound := min(lowerBound+q.Limit, len(res.Blobs))
 					res.Blobs = res.Blobs[lowerBound:upperBound]
 				} else {
 					res.Blobs = res.Blobs[:q.Limit]

--- a/pkg/search/query_test.go
+++ b/pkg/search/query_test.go
@@ -1549,7 +1549,7 @@ func testAroundUnsortedSource(limit, pos int, t *testing.T) {
 			unsorted[p.String()] = p
 			sorted = append(sorted, p.String())
 		}
-		for i := 0; i < 10; i++ {
+		for i := range 10 {
 			addToSorted(i)
 		}
 		sort.Strings(sorted)
@@ -1557,14 +1557,8 @@ func testAroundUnsortedSource(limit, pos int, t *testing.T) {
 		// Predict the results
 		var want []blob.Ref
 		var around blob.Ref
-		lowLimit := pos - limit/2
-		if lowLimit < 0 {
-			lowLimit = 0
-		}
-		highLimit := lowLimit + limit
-		if highLimit > len(sorted) {
-			highLimit = len(sorted)
-		}
+		lowLimit := max(pos-limit/2, 0)
+		highLimit := min(lowLimit+limit, len(sorted))
 		// Make the permanodes actually exist.
 		for k, v := range sorted {
 			pn := unsorted[v]
@@ -1974,7 +1968,7 @@ func BenchmarkQueryRecentPermanodes(b *testing.B) {
 		h := qt.Handler()
 		b.ResetTimer()
 
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			*req.Describe = DescribeRequest{}
 			_, err := h.Query(ctxbg, req)
 			if err != nil {
@@ -1997,7 +1991,7 @@ func benchmarkQueryPermanodes(b *testing.B, describe bool) {
 	testQueryTypes(b, corpusTypeOnly, func(qt *queryTest) {
 		id := qt.id
 
-		for i := 0; i < 1000; i++ {
+		for i := range 1000 {
 			pn := id.NewPlannedPermanode(fmt.Sprint(i))
 			id.SetAttribute(pn, "foo", fmt.Sprint(i))
 		}
@@ -2014,7 +2008,7 @@ func benchmarkQueryPermanodes(b *testing.B, describe bool) {
 		h := qt.Handler()
 		b.ResetTimer()
 
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			if describe {
 				*req.Describe = DescribeRequest{}
 			}
@@ -2056,18 +2050,18 @@ func BenchmarkQueryPermanodeLocation(b *testing.B) {
 		pn := id.NewPlannedPermanode("photo")
 		id.SetAttribute(pn, "camliContent", fileRef.String())
 
-		for i := 0; i < 5; i++ {
+		for i := range 5 {
 			pn := newPn()
 			id.SetAttribute(pn, "camliNodeType", "foursquare.com:venue")
 			id.SetAttribute(pn, "latitude", fmt.Sprint(50-i))
 			id.SetAttribute(pn, "longitude", fmt.Sprint(i))
-			for j := 0; j < 5; j++ {
+			for range 5 {
 				qn := newPn()
 				id.SetAttribute(qn, "camliNodeType", "foursquare.com:checkin")
 				id.SetAttribute(qn, "foursquareVenuePermanode", pn.String())
 			}
 		}
-		for i := 0; i < 10; i++ {
+		for i := range 10 {
 			pn := newPn()
 			id.SetAttribute(pn, "foo", fmt.Sprint(i))
 		}
@@ -2083,7 +2077,7 @@ func BenchmarkQueryPermanodeLocation(b *testing.B) {
 		h := qt.Handler()
 		b.ResetTimer()
 
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			_, err := h.Query(ctxbg, req)
 			if err != nil {
 				qt.t.Fatal(err)
@@ -2186,7 +2180,7 @@ func BenchmarkLocationPredicate(b *testing.B) {
 		// create 3K tweets, all with locations
 		lat := 45.18
 		long := 5.72
-		for i := 0; i < 3000; i++ {
+		for range 3000 {
 			pn := newPn()
 			id.SetAttribute(pn, "camliNodeType", "twitter.com:tweet")
 			id.SetAttribute(pn, "latitude", fmt.Sprintf("%f", lat))
@@ -2196,7 +2190,7 @@ func BenchmarkLocationPredicate(b *testing.B) {
 		}
 
 		// create 5K additional permanodes, but no location. Just as "noise".
-		for i := 0; i < 5000; i++ {
+		for range 5000 {
 			newPn()
 		}
 
@@ -2215,7 +2209,7 @@ func BenchmarkLocationPredicate(b *testing.B) {
 		locations := []string{
 			"canada", "scotland", "france", "sweden", "germany", "poland", "russia", "algeria", "congo", "china", "india", "australia", "mexico", "brazil", "argentina",
 		}
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			for _, loc := range locations {
 				req := &SearchQuery{
 					Expression: "loc:" + loc,
@@ -2433,7 +2427,7 @@ func TestBestByLocation(t *testing.T) {
 	const numResults = 5000
 	const limit = 117
 	const scale = 1000
-	for i := 0; i < numResults; i++ {
+	for i := range numResults {
 		br := blob.RefFromString(fmt.Sprintf("foo %d", i))
 		res.Blobs = append(res.Blobs, &SearchResultBlob{Blob: br})
 		locm[br] = camtypes.Location{

--- a/pkg/server/help.go
+++ b/pkg/server/help.go
@@ -169,8 +169,8 @@ func (hh *HelpHandler) serveHelpHTML(cc *clientconfig.Config, rw http.ResponseWr
 	}
 
 	var hint template.HTML
-	if strings.HasPrefix(hh.serverSecRing, "/gcs/") {
-		bucketdir := strings.TrimPrefix(hh.serverSecRing, "/gcs/")
+	if after, ok := strings.CutPrefix(hh.serverSecRing, "/gcs/"); ok {
+		bucketdir := after
 		bucketdir = strings.TrimSuffix(bucketdir, "/identity-secring.gpg")
 		hint = template.HTML(fmt.Sprintf("<p>Download your GnuPG secret ring from <a href=\"https://console.developers.google.com/storage/browser/%s/\">https://console.developers.google.com/storage/browser/%s/</a> and place it in your <a href='https://perkeep.org/doc/client-config'>Perkeep client config directory</a>. Keep it private. It's not encrypted or password-protected and anybody in possession of it can create Perkeep claims as your identity.</p>\n",
 			bucketdir, bucketdir))

--- a/pkg/server/import_share.go
+++ b/pkg/server/import_share.go
@@ -183,7 +183,7 @@ func (si *shareImporter) importAll(ctx context.Context) error {
 	defer close(si.workc)
 
 	// fan out over a pool of numWorkers workers overall
-	for i := 0; i < numWorkers; i++ {
+	for range numWorkers {
 		go func() {
 			for wi := range si.workc {
 				wi.errc <- si.imprt(ctx, wi.br)

--- a/pkg/server/share.go
+++ b/pkg/server/share.go
@@ -183,7 +183,7 @@ func (h *shareHandler) handleGetViaSharing(rw http.ResponseWriter, req *http.Req
 	}()
 	viaBlobs := make([]blob.Ref, 0)
 	if via := req.FormValue("via"); via != "" {
-		for _, vs := range strings.Split(via, ",") {
+		for vs := range strings.SplitSeq(via, ",") {
 			if br, ok := blob.Parse(vs); ok {
 				viaBlobs = append(viaBlobs, br)
 			} else {

--- a/pkg/server/sync.go
+++ b/pkg/server/sync.go
@@ -761,7 +761,6 @@ func (sh *SyncHandler) runFullValidation() {
 	gate := syncutil.NewGate(maxShardWorkers)
 
 	for _, pfx := range shards {
-		pfx := pfx
 		gate.Start()
 		go func() {
 			defer wg.Done()
@@ -894,7 +893,7 @@ func (sh *SyncHandler) shardPrefixes() []string {
 	// TODO(bradfitz): do limit=1 enumerates against sh.from and sh.to with varying
 	// "after" values to determine all the blobref types on both sides.
 	// For now, be lazy and assume only sha1 and sha224:
-	for i := 0; i < 256; i++ {
+	for i := range 256 {
 		pfx = append(pfx, fmt.Sprintf("sha1-%02x", i))
 		pfx = append(pfx, fmt.Sprintf("sha224-%02x", i))
 	}

--- a/pkg/serverinit/genconfig.go
+++ b/pkg/serverinit/genconfig.go
@@ -146,8 +146,8 @@ func (b *lowBuilder) dbName(of dbname) string {
 		return prefix + "uithumbmeta"
 	}
 	asString := string(of)
-	if strings.HasPrefix(asString, string(dbSyncQueue)) {
-		return prefix + "syncto_" + strings.TrimPrefix(asString, string(dbSyncQueue))
+	if after, ok := strings.CutPrefix(asString, string(dbSyncQueue)); ok {
+		return prefix + "syncto_" + after
 	}
 	return ""
 }

--- a/pkg/serverinit/serverinit.go
+++ b/pkg/serverinit/serverinit.go
@@ -308,9 +308,9 @@ func (hl *handlerLoader) setupHandler(prefix string) {
 
 	hl.curPrefix = prefix
 
-	if strings.HasPrefix(h.htype, "storage-") {
+	if after, ok0 := strings.CutPrefix(h.htype, "storage-"); ok0 {
 		// Assume a storage interface:
-		stype := strings.TrimPrefix(h.htype, "storage-")
+		stype := after
 		pstorage, err := blobserver.CreateStorage(stype, hl, h.conf)
 		if err != nil {
 			exitFailure("error instantiating storage for prefix %q, type %q: %v",

--- a/pkg/sorted/kvtest/kvtest.go
+++ b/pkg/sorted/kvtest/kvtest.go
@@ -47,7 +47,7 @@ func TestSorted(t *testing.T, kv sorted.KeyValue) {
 	if v, err := kv.Get("NOT_EXIST"); !errors.Is(err, sorted.ErrNotFound) {
 		t.Errorf("get(NOT_EXIST) = %q, %v; want error sorted.ErrNotFound", v, err)
 	}
-	for i := 0; i < 2; i++ {
+	for i := range 2 {
 		if err := kv.Delete("foo"); err != nil {
 			t.Errorf("Delete(foo) (on loop %d/2) returned error %v", i+1, err)
 		}

--- a/pkg/sorted/postgres/postgreskv.go
+++ b/pkg/sorted/postgres/postgreskv.go
@@ -147,7 +147,7 @@ var replacePlaceHolders = func(query string) string {
 	i := 0
 	dollarInc := func(b []byte) []byte {
 		i++
-		return []byte(fmt.Sprintf("$%d", i))
+		return fmt.Appendf(nil, "$%d", i)
 	}
 	return string(qmark.ReplaceAllFunc([]byte(query), dollarInc))
 }

--- a/pkg/sorted/sqlkv/sqlkv_test.go
+++ b/pkg/sorted/sqlkv/sqlkv_test.go
@@ -53,7 +53,7 @@ func TestSql(t *testing.T) {
 }
 
 func BenchmarkSql(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		for _, s := range queries {
 			kv.sql(s)
 		}

--- a/pkg/test/integration/diskpacked_test.go
+++ b/pkg/test/integration/diskpacked_test.go
@@ -47,9 +47,8 @@ func benchmarkWrite(b *testing.B, cfg string) {
 	testFile := filepath.Join(w.SourceRoot(), testFileRel)
 	createTestFile(b, testFile, testFileSize)
 	defer os.Remove(testFile)
-	b.ResetTimer()
-	b.StopTimer()
-	for i := 0; i < b.N; i++ {
+
+	for b.Loop() {
 		err = w.Start()
 		if err != nil {
 			b.Fatalf("could not start server for config: %v\nError: %v", cfg, err)

--- a/pkg/test/world.go
+++ b/pkg/test/world.go
@@ -208,7 +208,7 @@ func (w *World) Start() error {
 			}
 			w.addr = strings.TrimSpace(addr)
 
-			for i := 0; i < 100; i++ {
+			for range 100 {
 				res, err := http.Get("http://" + w.addr)
 				if err == nil {
 					res.Body.Close()

--- a/website/pk-web/pkweb.go
+++ b/website/pk-web/pkweb.go
@@ -237,8 +237,7 @@ func redirectPath(u *url.URL) string {
 		}
 	}
 
-	if strings.HasPrefix(u.Path, "/gw/") {
-		path := strings.TrimPrefix(u.Path, "/gw/")
+	if path, ok := strings.CutPrefix(u.Path, "/gw/"); ok {
 		if commitHash.MatchString(path) {
 			// Assume it's a commit
 			return viewCommitPrefix + path
@@ -246,8 +245,8 @@ func redirectPath(u *url.URL) string {
 		return viewFilePrefix + "master/" + path
 	}
 
-	if strings.HasPrefix(u.Path, "/docs/") {
-		return "/doc/" + strings.TrimPrefix(u.Path, "/docs/")
+	if after, ok := strings.CutPrefix(u.Path, "/docs/"); ok {
+		return "/doc/" + after
 	}
 
 	// strip directory index files


### PR DESCRIPTION
This runs:

    go run golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest -fix \
        -category=bloop,rangeint,stringsseq,stringscutprefix,waitgroup,bloop,fmtappendf,forvar,minmax \
	./...

As pointed out by @lotusirous in #1749. (Re-running it is an easier
way to review, compared to auditing all of #1749)
