### PR TITLE
fix `TestQuery`: Cleanup canSourceHook

### DIFF
--- a/pkg/search/query_test.go
+++ b/pkg/search/query_test.go
@@ -156,6 +156,9 @@ func (qt *queryTest) wantRes(req *SearchQuery, wanted ...blob.Ref) {
 				qt.t.Fatalf("unexpected candidateSource: got %v, want %v", pickedCandidate, qt.candidateSource)
 			}
 		})
+		qt.t.Cleanup(func() {
+			ExportSetCandidateSourceHook(nil)
+		})
 	}
 	res, err := qt.Handler().Query(ctxbg, req)
 	if err != nil {


### PR DESCRIPTION
## What

Cleanup global hook after test completes

## Why

`TestQuery` starts to fail when we run the test multiple tests, and the error message was:
```go
unexpected candidateSource: got index_blob_meta, want corpus_permanode_types
```

I believe the failure scenario is related to shared resource leakage:

1. `TestIsCheckinQuerySource` runs and sets the hook to expect "corpus_permanode_types"
2. The test completes, but the hook remains set globally
3. `TestQuery` runs next (or concurrently in parallel execution)
4. `TestQuery`'s query picks "index_blob_meta" as the candidate source
5. The old hook from `TestIsCheckinQuerySource` is still active and gets called
6. The hook panics because it expects "corpus_permanode_types" but receives "index_blob_meta"
7. Since the panic happens in a goroutine after `TestIsCheckinQuerySource` has already finished, Go's testing framework detects this as "Log in goroutine after test has completed"

## Related

fix #1702 