### PR TITLE
cmd/pk-put: deflake tests on Windows

### DIFF
--- a/cmd/pk-put/blobs.go
+++ b/cmd/pk-put/blobs.go
@@ -88,6 +88,7 @@ func (c *blobCmd) RunCommand(args []string) error {
 			return cmdmain.UsageError("A GPG key is needed to create permanodes; configure one or use vivify mode.")
 		}
 	}
+	defer up.Close() // release resources when done; let Windows tests clean up temp dirs
 
 	var (
 		handle    *client.UploadHandle

--- a/pkg/blobserver/diskpacked/diskpacked.go
+++ b/pkg/blobserver/diskpacked/diskpacked.go
@@ -124,6 +124,7 @@ func IsDir(dir string) (bool, error) {
 func New(dir string) (blobserver.Storage, error) {
 	var maxSize int64
 	if dh, err := os.Open(dir); err == nil {
+		defer dh.Close()
 		var nBlobFiles, atMax int
 		if fis, err := dh.Readdir(-1); err == nil {
 			// Detect existing max size from size of files, if obvious, and set maxSize to that


### PR DESCRIPTION
It was often failing to clean up a temp directory that was still open
by the Uploader.

e.g.

https://github.com/perkeep/perkeep/actions/runs/19998669505/job/57473421998?pr=1765
```
--- FAIL: TestCamputBlob (2.22s)
    testing.go:1369: TempDir RemoveAll cleanup: unlinkat C:\Users\RUNNER~1\AppData\Local\Temp\TestCamputBlob1048664309\001\blob_dest: The process cannot access the file because it is being used by another process.
FAIL
FAIL	perkeep.org/cmd/pk-put	3.585s
```