### PR TITLE
dev/devcam, *: remove old sqlite3 dep references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,10 +36,6 @@ misc/docker/djpeg-static/djpeg.tar.gz
 misc/docker/perkeepd/perkeepd*
 misc/docker/perkeepd/djpeg
 
-# not vendored in, because we build with the system's libsqlite3
-/vendor/github.com/mattn/go-sqlite3/sqlite3-binding.c
-/vendor/github.com/mattn/go-sqlite3/sqlite3-binding.h
-
 # vendored data we don't want to retain
 /vendor/**/.travis.yml
 /vendor/**/.gitignore

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ hack from a Perkeep release's zip file:
 
 On Debian/Ubuntu, some deps to get started:
 
-    $ sudo apt-get install libsqlite3-dev sqlite3 pkg-config git
+    $ sudo apt-get install pkg-config git
 
 During development, rather than using the main binaries ("pk", "pk-put",
 "pk-get", "pk-mount", etc) directly, we instead use a wrapper (devcam)

--- a/dev/devcam/test.go
+++ b/dev/devcam/test.go
@@ -38,7 +38,6 @@ type testCmd struct {
 	short     bool
 	race      bool
 	run       string
-	sqlite    bool
 }
 
 func init() {
@@ -49,7 +48,6 @@ func init() {
 		flags.BoolVar(&cmd.precommit, "precommit", true, "Run the pre-commit githook as part of tests.")
 		flags.BoolVar(&cmd.verbose, "v", false, "Use '-v' (for verbose) with go test.")
 		flags.StringVar(&cmd.run, "run", "", "Use '-run' with go test.")
-		flags.BoolVar(&cmd.sqlite, "sqlite", true, "Run tests with SQLite built-in where relevant.")
 		return cmd
 	})
 }
@@ -122,11 +120,7 @@ func (c *testCmd) buildSelf() error {
 
 func (c *testCmd) runTests(args []string) error {
 	targs := []string{"test"}
-	if c.sqlite {
-		targs = append(targs, "--tags=with_sqlite fake_android libsqlite3")
-	} else {
-		targs = append(targs, "--tags=fake_android")
-	}
+	targs = append(targs, "--tags=fake_android")
 	if c.short {
 		targs = append(targs, "-short")
 	}

--- a/pkg/index/stress/index_test.go
+++ b/pkg/index/stress/index_test.go
@@ -458,7 +458,7 @@ func benchmarkKillReindex(b *testing.B, killTimeFactor int, dbfile string,
 	sortedProvider func(dbfile string) (sorted.KeyValue, error)) {
 	cmd := exec.Command("go", "test", "-c")
 	if strings.HasSuffix(dbfile, "sqlite.db") {
-		cmd = exec.Command("go", "test", "--tags", "with_sqlite", "-c")
+		cmd = exec.Command("go", "test", "-c")
 	}
 	if err := cmd.Run(); err != nil {
 		b.Fatal(err)


### PR DESCRIPTION
(no longer needed since c986ee3, which converted the tree to use
modernc.org/sqlite without cgo)
