### PR TITLE
pkg/importer/raindrop: fix panic in tests in CI

### DIFF
--- a/dev/devcam/test.go
+++ b/dev/devcam/test.go
@@ -148,6 +148,7 @@ func (c *testCmd) runTests(args []string) error {
 	}
 	env := c.env()
 	env.Set("SKIP_DEP_TESTS", "1")
+	env.Set("CAMLI_DISABLE_CLIENT_CONFIG_FILE", "1")
 	return runExec("go", targs, env)
 }
 

--- a/pkg/client/upload.go
+++ b/pkg/client/upload.go
@@ -127,7 +127,8 @@ func parseStatResponse(res *http.Response) (*statResponse, error) {
 	return s, nil
 }
 
-// NewUploadHandleFromString returns an upload handle
+// NewUploadHandleFromString returns an upload handle to upload
+// the provided string as a blob.
 func NewUploadHandleFromString(data string) *UploadHandle {
 	bref := blob.RefFromString(data)
 	r := strings.NewReader(data)


### PR DESCRIPTION
We can't just use "client.New" in a package-level init: that uses the
user's client config files, but the server may not have a client
configured for the user it's running as.

Instead, we need to upload blobs to the importer's Host.