### PR TITLE
pkg/blob: add sha256 blob support as well (in addition to the sha224 default)

### DIFF
--- a/pkg/blobserver/enumerate.go
+++ b/pkg/blobserver/enumerate.go
@@ -65,13 +65,3 @@ func EnumerateAllFrom(ctx context.Context, src BlobEnumerator, after string, fn 
 		}
 	}
 }
-
-// RefTypes returns a list of blobref types appearing on the provided enumerator.
-// A blobref type is a string like "sha1", or whatever is on the left side
-// of the hyphen in a blobref.
-// To get the alphabet valid for the right side of the hyphen, use blob.TypeAlphabet(type).
-func RefTypes(src BlobEnumerator) ([]string, error) {
-	// TODO(bradfitz): implement, with various short enumerate
-	// reads at the right places.
-	return []string{"sha1"}, nil
-}


### PR DESCRIPTION
This keeps the SHA-224 blob type as the default, but lets clients upload
as SHA-256 if they'd like.

Updates #537
Updates #1694
